### PR TITLE
fix: normalize CSV MIME type detection in InvoiceSuiteAttachment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     "require": {
         "php": ">=8.2",
         "ext-dom": "*",
+        "ext-fileinfo": "*",
         "ext-mbstring": "*",
         "ext-simplexml": "*",
         "doctrine/annotations": "^2.0",
@@ -62,7 +63,7 @@
         "jms/serializer": "^3",
         "mpdf/mpdf": "^8",
         "prinsfrank/pdfparser": "^2",
-        "setasign/fpdf": "^1",
+        "setasign/fpdf": "^1.8.6",
         "setasign/fpdi": "^2.6.4",
         "symfony/console": "^5.4.46 || ^6.4.14 || ^7.1.7 || ^8",
         "symfony/finder": "^5 || ^6 || ^7 || ^8",

--- a/src/utils/InvoiceSuiteAttachment.php
+++ b/src/utils/InvoiceSuiteAttachment.php
@@ -62,6 +62,13 @@ class InvoiceSuiteAttachment
     protected $internalFilename = '';
 
     /**
+     * The original filename extension (lowercase, without dot)
+     *
+     * @var string
+     */
+    protected $internalFilenameExtension = '';
+
+    /**
      * Constructor (hidden)
      *
      * @param string $internalContent
@@ -76,6 +83,7 @@ class InvoiceSuiteAttachment
         $this->internalType = $internalType;
         $this->internalContent = $internalContent;
         $this->internalFilename = InvoiceSuiteFileUtils::getFilenameWithoutExtension($internalFilename);
+        $this->internalFilenameExtension = strtolower(InvoiceSuiteFileUtils::getFileExtension($internalFilename));
     }
 
     /**
@@ -230,15 +238,20 @@ class InvoiceSuiteAttachment
      *
      * @return false|string
      */
-    public function getContentMimeType()
+    public function getContentMimeType(): false|string
     {
         if (!$this->isBinaryAttachment()) {
             return false;
         }
 
         $tempFileInfo = new finfo(FILEINFO_MIME_TYPE);
+        $mimeType = $tempFileInfo->buffer($this->internalContent);
 
-        return $tempFileInfo->buffer($this->internalContent);
+        if ($mimeType === 'text/plain' && $this->internalFilenameExtension === 'csv') {
+            return 'text/csv';
+        }
+
+        return $mimeType;
     }
 
     /**
@@ -246,7 +259,7 @@ class InvoiceSuiteAttachment
      *
      * @return false|string
      */
-    public function getFilename()
+    public function getFilename(): false|string
     {
         if (!$this->isBinaryAttachment()) {
             return false;

--- a/src/utils/InvoiceSuiteAttachment.php
+++ b/src/utils/InvoiceSuiteAttachment.php
@@ -247,7 +247,7 @@ class InvoiceSuiteAttachment
         $tempFileInfo = new finfo(FILEINFO_MIME_TYPE);
         $mimeType = $tempFileInfo->buffer($this->internalContent);
 
-        if ($mimeType === 'text/plain' && $this->internalFilenameExtension === 'csv') {
+        if ('text/plain' === $mimeType && 'csv' === $this->internalFilenameExtension) {
             return 'text/csv';
         }
 

--- a/tests/assets/01_InvoiceSuiteAttachment_3.csv
+++ b/tests/assets/01_InvoiceSuiteAttachment_3.csv
@@ -1,0 +1,6 @@
+id,name,email,city,created_at,status,amount_eur
+1,Max Mustermann,max.mustermann@example.com,Berlin,2026-01-01,active,129.90
+2,Erika Musterfrau,erika.musterfrau@example.com,Hamburg,2026-01-02,inactive,49.50
+3,Paul Beispiel,paul.beispiel@example.com,München,2026-01-03,active,199.00
+4,Lena Demo,lena.demo@example.com,Köln,2026-01-03,active,15.99
+5,Tobias Test,tobias.test@example.com,Frankfurt,2026-01-04,pending,0.00

--- a/tests/assets/01_InvoiceSuiteAttachment_4.csv
+++ b/tests/assets/01_InvoiceSuiteAttachment_4.csv
@@ -1,0 +1,6 @@
+"id";"name";"email";"city";"created_at";"status";"amount_eur"
+"1";"Max Mustermann";"max.mustermann@example.com";"Berlin";"2026-01-01";"active";"129.90"
+"2";"Erika Musterfrau";"erika.musterfrau@example.com";"Hamburg";"2026-01-02";"inactive";"49.50"
+"3";"Paul Beispiel";"paul.beispiel@example.com";"München";"2026-01-03";"active";"199.00"
+"4";"Lena Demo";"lena.demo@example.com";"Köln";"2026-01-03";"active";"15.99"
+"5";"Tobias Test";"tobias.test@example.com";"Frankfurt";"2026-01-04";"pending";"0.00"

--- a/tests/testcases/utils/UtilsTest.php
+++ b/tests/testcases/utils/UtilsTest.php
@@ -889,6 +889,76 @@ final class UtilsTest extends TestCase
         // InvoiceSuiteAttachment::fromUrl('Dummy');
     }
 
+    public function testInvoiceSuiteAttachmentCsvNativeFormatFromFile(): void
+    {
+        $attachment = InvoiceSuiteAttachment::fromFile(__DIR__ . '/../../assets/01_InvoiceSuiteAttachment_3.csv');
+
+        $this->assertInstanceOf(InvoiceSuiteAttachment::class, $attachment);
+        $this->assertTrue($attachment->isFileAttachment());
+        $this->assertTrue($attachment->isBinaryAttachment());
+        $this->assertSame('text/csv', $attachment->getContentMimeType());
+        $this->assertSame('01_InvoiceSuiteAttachment_3.csv', $attachment->getFilename());
+    }
+
+    public function testInvoiceSuiteAttachmentCsvNativeFormatFromBinaryString(): void
+    {
+        $csvContent = (string) file_get_contents(__DIR__ . '/../../assets/01_InvoiceSuiteAttachment_3.csv');
+        $attachment = InvoiceSuiteAttachment::fromBinaryString($csvContent, '01_InvoiceSuiteAttachment_3.csv');
+
+        $this->assertInstanceOf(InvoiceSuiteAttachment::class, $attachment);
+        $this->assertTrue($attachment->isBinaryStringAttachment());
+        $this->assertTrue($attachment->isBinaryAttachment());
+        $this->assertSame('text/csv', $attachment->getContentMimeType());
+        $this->assertSame('01_InvoiceSuiteAttachment_3.csv', $attachment->getFilename());
+    }
+
+    public function testInvoiceSuiteAttachmentCsvNativeFormatFromBase64String(): void
+    {
+        $csvContent = (string) file_get_contents(__DIR__ . '/../../assets/01_InvoiceSuiteAttachment_3.csv');
+        $attachment = InvoiceSuiteAttachment::fromBase64String(base64_encode($csvContent), '01_InvoiceSuiteAttachment_3.csv');
+
+        $this->assertInstanceOf(InvoiceSuiteAttachment::class, $attachment);
+        $this->assertTrue($attachment->isBase64StringAttachment());
+        $this->assertTrue($attachment->isBinaryAttachment());
+        $this->assertSame('text/csv', $attachment->getContentMimeType());
+        $this->assertSame('01_InvoiceSuiteAttachment_3.csv', $attachment->getFilename());
+    }
+
+    public function testInvoiceSuiteAttachmentCsvCustomFormatFromFile(): void
+    {
+        $attachment = InvoiceSuiteAttachment::fromFile(__DIR__ . '/../../assets/01_InvoiceSuiteAttachment_4.csv');
+
+        $this->assertInstanceOf(InvoiceSuiteAttachment::class, $attachment);
+        $this->assertTrue($attachment->isFileAttachment());
+        $this->assertTrue($attachment->isBinaryAttachment());
+        $this->assertSame('text/csv', $attachment->getContentMimeType());
+        $this->assertSame('01_InvoiceSuiteAttachment_4.csv', $attachment->getFilename());
+    }
+
+    public function testInvoiceSuiteAttachmentCsvCustomFormatFromBinaryString(): void
+    {
+        $csvContent = (string) file_get_contents(__DIR__ . '/../../assets/01_InvoiceSuiteAttachment_4.csv');
+        $attachment = InvoiceSuiteAttachment::fromBinaryString($csvContent, '01_InvoiceSuiteAttachment_4.csv');
+
+        $this->assertInstanceOf(InvoiceSuiteAttachment::class, $attachment);
+        $this->assertTrue($attachment->isBinaryStringAttachment());
+        $this->assertTrue($attachment->isBinaryAttachment());
+        $this->assertSame('text/csv', $attachment->getContentMimeType());
+        $this->assertSame('01_InvoiceSuiteAttachment_4.csv', $attachment->getFilename());
+    }
+
+    public function testInvoiceSuiteAttachmentCsvCustomFormatFromBase64String(): void
+    {
+        $csvContent = (string) file_get_contents(__DIR__ . '/../../assets/01_InvoiceSuiteAttachment_4.csv');
+        $attachment = InvoiceSuiteAttachment::fromBase64String(base64_encode($csvContent), '01_InvoiceSuiteAttachment_4.csv');
+
+        $this->assertInstanceOf(InvoiceSuiteAttachment::class, $attachment);
+        $this->assertTrue($attachment->isBase64StringAttachment());
+        $this->assertTrue($attachment->isBinaryAttachment());
+        $this->assertSame('text/csv', $attachment->getContentMimeType());
+        $this->assertSame('01_InvoiceSuiteAttachment_4.csv', $attachment->getFilename());
+    }
+
     public function testInvoiceSuiteClassFinderFactory(): void
     {
         $cacheFilename = md5((string) preg_replace('/[^a-zA-Z0-9]/', '', sprintf('invoicesuite-cf-%s', InvoiceSuiteAbstractDocumentFormatProvider::class))) . '.cache';


### PR DESCRIPTION
# Description

`finfo::buffer()` detects plain-text CSV files as `text/plain` instead of `text/csv`, because CSV has no magic bytes and the content is indistinguishable from plain text without the file extension. 

This fix ports the same corrections that were applied to `horstoeko/zugferd` in the companion PRs for issue #337.

**Changes in `InvoiceSuiteAttachment`:**
- Added `$internalFilenameExtension` property to preserve the original file extension before it is stripped by the constructor
- `getContentMimeType()` now normalizes `text/plain` → `text/csv` when the original filename extension is `csv`

The fix applies to all three attachment creation paths (`fromFile`, `fromBinaryString`, `fromBase64String`), including the reader path where attachments are reconstructed from base64-encoded XML content.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Six new test methods were added to `UtilsTest`, covering both CSV formats (native comma-separated and custom semicolon-separated) across all three construction paths:

- [x] `testInvoiceSuiteAttachmentCsvNativeFormatFromFile`
- [x] `testInvoiceSuiteAttachmentCsvNativeFormatFromBinaryString`
- [x] `testInvoiceSuiteAttachmentCsvNativeFormatFromBase64String`
- [x] `testInvoiceSuiteAttachmentCsvCustomFormatFromFile`
- [x] `testInvoiceSuiteAttachmentCsvCustomFormatFromBinaryString`
- [x] `testInvoiceSuiteAttachmentCsvCustomFormatFromBase64String`
