### PR TITLE
[FIX] Legacy Support is missing Delivery

### DIFF
--- a/src/documents/providers/zffx/InvoiceSuiteZfFxProviderBuilder.php
+++ b/src/documents/providers/zffx/InvoiceSuiteZfFxProviderBuilder.php
@@ -63,6 +63,21 @@ class InvoiceSuiteZfFxProviderBuilder extends InvoiceSuiteAbstractDocumentFormat
             $this->getCurrentDocumentFormatProviderParameterValue('BusinessProcess', '')
         );
 
+        $this
+            ->getCrossIndustryRootObject()
+            ->getSupplyChainTradeTransactionWithCreate()
+            ->getApplicableHeaderTradeAgreementWithCreate();
+
+        $this
+            ->getCrossIndustryRootObject()
+            ->getSupplyChainTradeTransactionWithCreate()
+            ->getApplicableHeaderTradeDeliveryWithCreate();
+
+        $this
+            ->getCrossIndustryRootObject()
+            ->getSupplyChainTradeTransactionWithCreate()
+            ->getApplicableHeaderTradeSettlementWithCreate();
+
         return $this;
     }
 

--- a/tests/testcases/documentcases/XRechnungCIIDocumentBuilderDTOTest.php
+++ b/tests/testcases/documentcases/XRechnungCIIDocumentBuilderDTOTest.php
@@ -186,6 +186,10 @@ final class XRechnungCIIDocumentBuilderDTOTest extends TestCase
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID', 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID)[2]');
 
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
+
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID', '471102');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID)[2]');
 

--- a/tests/testcases/documentcases/XRechnungCIIDocumentBuilderTest.php
+++ b/tests/testcases/documentcases/XRechnungCIIDocumentBuilderTest.php
@@ -148,6 +148,10 @@ final class XRechnungCIIDocumentBuilderTest extends TestCase
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID', 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID)[2]');
 
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
+
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID', '471102');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID)[2]');
 

--- a/tests/testcases/documentcases/ZfFxComfortDocumentBuilderDTOTest.php
+++ b/tests/testcases/documentcases/ZfFxComfortDocumentBuilderDTOTest.php
@@ -184,6 +184,10 @@ final class ZfFxComfortDocumentBuilderDTOTest extends TestCase
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID', 'urn:cen.eu:en16931:2017');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID)[2]');
 
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
+
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID', '471102');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID)[2]');
 

--- a/tests/testcases/documentcases/ZfFxComfortDocumentBuilderTest.php
+++ b/tests/testcases/documentcases/ZfFxComfortDocumentBuilderTest.php
@@ -146,6 +146,10 @@ final class ZfFxComfortDocumentBuilderTest extends TestCase
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID', 'urn:cen.eu:en16931:2017');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID)[2]');
 
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
+
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID', '471102');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID)[2]');
 

--- a/tests/testcases/documentcases/ZfFxExtendedDocumentBuilderDTOTest.php
+++ b/tests/testcases/documentcases/ZfFxExtendedDocumentBuilderDTOTest.php
@@ -425,6 +425,10 @@ final class ZfFxExtendedDocumentBuilderDTOTest extends TestCase
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID', 'urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID)[2]');
 
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
+
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID', 'R87654321012345');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID)[2]');
 

--- a/tests/testcases/documentcases/ZfFxExtendedDocumentBuilderTest.php
+++ b/tests/testcases/documentcases/ZfFxExtendedDocumentBuilderTest.php
@@ -377,6 +377,10 @@ final class ZfFxExtendedDocumentBuilderTest extends TestCase
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID', 'urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID)[2]');
 
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
+
         $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID', 'R87654321012345');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:ExchangedDocument/ram:ID)[2]');
 

--- a/tests/testcases/documentproviders/XRechnungCIIInvoiceProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/XRechnungCIIInvoiceProviderBuilderTest.php
@@ -36,6 +36,10 @@ final class XRechnungCIIInvoiceProviderBuilderTest extends TestCase
         static::$document->initDocumentRootObject();
 
         $this->assertInstanceOf(CrossIndustryInvoice::class, static::$document->getDocumentRootObject());
+
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
     }
 
     public function testDocumentProfile(): void

--- a/tests/testcases/documentproviders/ZfFxBasicProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/ZfFxBasicProviderBuilderTest.php
@@ -36,6 +36,10 @@ final class ZfFxBasicProviderBuilderTest extends TestCase
         static::$document->initDocumentRootObject();
 
         $this->assertInstanceOf(CrossIndustryInvoice::class, static::$document->getDocumentRootObject());
+
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
     }
 
     public function testDocumentProfile(): void

--- a/tests/testcases/documentproviders/ZfFxBasicWlProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/ZfFxBasicWlProviderBuilderTest.php
@@ -36,6 +36,10 @@ final class ZfFxBasicWlProviderBuilderTest extends TestCase
         static::$document->initDocumentRootObject();
 
         $this->assertInstanceOf(CrossIndustryInvoice::class, static::$document->getDocumentRootObject());
+
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
     }
 
     public function testDocumentProfile(): void

--- a/tests/testcases/documentproviders/ZfFxComfortProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/ZfFxComfortProviderBuilderTest.php
@@ -36,6 +36,10 @@ final class ZfFxComfortProviderBuilderTest extends TestCase
         static::$document->initDocumentRootObject();
 
         $this->assertInstanceOf(CrossIndustryInvoice::class, static::$document->getDocumentRootObject());
+
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
     }
 
     public function testDocumentProfile(): void

--- a/tests/testcases/documentproviders/ZfFxExtendedProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/ZfFxExtendedProviderBuilderTest.php
@@ -36,6 +36,10 @@ final class ZfFxExtendedProviderBuilderTest extends TestCase
         static::$document->initDocumentRootObject();
 
         $this->assertInstanceOf(CrossIndustryInvoice::class, static::$document->getDocumentRootObject());
+
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
     }
 
     public function testDocumentProfile(): void

--- a/tests/testcases/documentproviders/ZfFxMinimumProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/ZfFxMinimumProviderBuilderTest.php
@@ -36,6 +36,10 @@ final class ZfFxMinimumProviderBuilderTest extends TestCase
         static::$document->initDocumentRootObject();
 
         $this->assertInstanceOf(CrossIndustryInvoice::class, static::$document->getDocumentRootObject());
+
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery');
+        $this->assertXPathExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement');
     }
 
     public function testDocumentProfile(): void


### PR DESCRIPTION
# Description

While switching from zugferd library to the new invoicesuite library via the legacy path (drop in replacement) new XML Documents become invalid. The old library set an empty ApplicableHeaderTradeDelivery which the new one does not thus invalidating the XML File. As for digital products there is no physical delivery. This was fixed.

Fixes #21 

# Type of change

Select all applicable options.

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring without functional changes
- [ ] Performance improvement
- [ ] Documentation change
- [ ] Breaking change
- [ ] Other
