### PR TITLE
Add EXTENDED-CTC-FR cii support

### DIFF
--- a/src/documents/providers/zffx/InvoiceSuiteZfFxExtendedProvider.php
+++ b/src/documents/providers/zffx/InvoiceSuiteZfFxExtendedProvider.php
@@ -64,7 +64,10 @@ class InvoiceSuiteZfFxExtendedProvider extends InvoiceSuiteAbstractDocumentForma
     {
         return [
             'ContextParameter' => 'urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended',
-            'AlternativeContextParameters' => ['urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p0:extended'],
+            'AlternativeContextParameters' => [
+                'urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p0:extended',
+                'urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr',
+            ],
             'BusinessProcess' => 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
             'PdfXmpName' => 'EXTENDED',
             'PdfXmpVersion' => '1.0',

--- a/tests/testcases/documentproviders/ZfFxExtendedProviderTest.php
+++ b/tests/testcases/documentproviders/ZfFxExtendedProviderTest.php
@@ -40,8 +40,9 @@ final class ZfFxExtendedProviderTest extends TestCase
         $this->assertSame('urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended', $provider->getParameters()['ContextParameter']);
 
         $this->assertIsArray($provider->getParameters()['AlternativeContextParameters']);
-        $this->assertCount(1, $provider->getParameters()['AlternativeContextParameters']);
+        $this->assertCount(2, $provider->getParameters()['AlternativeContextParameters']);
         $this->assertContains('urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p0:extended', $provider->getParameters()['AlternativeContextParameters']);
+        $this->assertContains('urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr', $provider->getParameters()['AlternativeContextParameters']);
 
         $this->assertIsString($provider->getParameters()['BusinessProcess']);
         $this->assertSame('urn:fdc:peppol.eu:2017:poacc:billing:01:1.0', $provider->getParameters()['BusinessProcess']);
@@ -152,6 +153,35 @@ final class ZfFxExtendedProviderTest extends TestCase
                 </ram:BusinessProcessSpecifiedDocumentContextParameter>
                 <ram:GuidelineSpecifiedDocumentContextParameter>
                     <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p0:extended</ram:ID>
+                </ram:GuidelineSpecifiedDocumentContextParameter>
+            </rsm:ExchangedDocumentContext>
+        </rsm:CrossIndustryInvoice>
+        XML_WRAP;
+
+        $this->assertTrue($provider->getIsSatisfiableBySerializedContent($xml));
+
+        $xml = <<<'XML_WRAP'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <rsm:ExchangedDocumentContext>
+                <ram:BusinessProcessSpecifiedDocumentContextParameter>
+                    <ram:ID>B1</ram:ID>
+                </ram:BusinessProcessSpecifiedDocumentContextParameter>
+                <ram:GuidelineSpecifiedDocumentContextParameter>
+                    <ram:ID>urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr</ram:ID>
+                </ram:GuidelineSpecifiedDocumentContextParameter>
+            </rsm:ExchangedDocumentContext>
+        </rsm:CrossIndustryInvoice>
+        XML_WRAP;
+
+        $this->assertTrue($provider->getIsSatisfiableBySerializedContent($xml));
+
+        $xml = <<<'XML_WRAP'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <rsm:ExchangedDocumentContext>
+                <ram:GuidelineSpecifiedDocumentContextParameter>
+                    <ram:ID>urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr</ram:ID>
                 </ram:GuidelineSpecifiedDocumentContextParameter>
             </rsm:ExchangedDocumentContext>
         </rsm:CrossIndustryInvoice>


### PR DESCRIPTION
# Description

France's e-invoicing reform defines a national CIUS of EN 16931, **EXTENDED-CTC-FR**
(AFNOR XP Z12-012). Its specification identifier (BT-24) is

```
urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr
```

(note the dot in `urn.cpro.gouv.fr` — that is what the specification says; verified against
XP Z12-012 Annexe A as published in https://github.com/fnfempe/France_RFE).

CII documents carrying it were not recognised by any shipped provider, so
`InvoiceSuiteDocumentReader::createFromContent()` threw
`InvoiceSuiteFormatProviderNotFoundException('unknown')` on documents that are already
exchanged in production in France.

CTC-FR EXTENDED is a *conformant* CIUS of Factur-X EXTENDED and uses exactly the same ram/rsm
models — XP Z12-012 Annexe A says so explicitly ("Factur-X EXTENDED-CTC-FR qui est un subset
du profil EXTENDED de Factur-X"). `InvoiceSuiteZfFxExtendedProvider::getSerializedContentMatchesScheme()`
already merges `ContextParameter` with `AlternativeContextParameters` and ignores the business
process (BT-23), so registering the identifier as an alternative — next to the existing
ZUGFeRD 2.0 one — is sufficient.

This is **detection-only**: `InvoiceSuiteZfFxProviderBuilder::initDocumentRootObject()` writes
only the primary `ContextParameter`, so building keeps emitting the Factur-X EXTENDED
identifier, exactly as it does for the ZUGFeRD 2.0 alternative today.

The French business process identifier (BT-23,
`ram:BusinessProcessSpecifiedDocumentContextParameter/ram:ID`) is an AFNOR "cadre de
facturation" code — `B1`, `S1`, `M1`, … — rather than a profile URN, and is sometimes absent.
The EXTENDED matcher never looks at it, so no change is needed there; the added tests cover
both a `B1` business process and a missing one.

No new dependencies.

# Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring without functional changes
- [ ] Performance improvement
- [ ] Documentation change
- [ ] Breaking change
- [ ] Other

# Testing

```bash
composer testsreal:providers:quick   # OK
composer testsreal:quick             # full suite, OK
composer phpcsfixer:run              # no changes
composer phpstan:run                 # no errors
composer rector:dryrun               # no changes
```

Test cases added to `tests/testcases/documentproviders/ZfFxExtendedProviderTest.php`:

- `testGetParameters()` — asserts the two alternative context parameters.
- `testIsSatisfiableBy()` — two new positive cases, one with
  `<ram:ID>B1</ram:ID>` as the business process and one with no
  `BusinessProcessSpecifiedDocumentContextParameter` at all. The existing negative case
  (plain `urn:cen.eu:en16931:2017`, which belongs to the Comfort provider) is unchanged, so
  the profiles stay mutually exclusive — which matters because detection is first-match-wins.

Fixtures are inline synthetic XML, in the same heredoc style as the surrounding tests. No
AFNOR sample document is used: the XP Z12-012 Annexe B test set is explicitly not free of
rights.

End-to-end check with a synthetic document (kept outside the repository):

```
$ php bin/invoicesuite invoicesuite:detect ctcfr_cii.xml --output-json
{
    "id": "zffxextended",
    "description": "The EXTENDED profile is an extension of EN 16931-1 ...",
    "error": false
}
```

**Test configuration**

- Operating system: Debian GNU/Linux
- Operating system version: 12 (bookworm)
- PHP version: 8.4.25
- Relevant dependency versions: as locked by `composer update --prefer-dist` on `master` (v0.0.27)

# Mandatory checklist

- [x] This pull request contains one logical change.
- [x] I have explained why this change is necessary.
- [x] I have personally reviewed every changed file.
- [x] I understand the submitted code and can explain how it works.
- [x] I have tested the change locally.
- [x] Existing tests pass locally.
- [x] My changes introduce no new warnings or static-analysis errors.
- [x] I have added or updated meaningful tests where applicable.
- [x] I have updated the documentation where necessary.
- [x] I have not included unrelated formatting, generated, or mechanical changes.
- [x] I accept full responsibility for automated or AI-assisted content contained in this pull request.

# Additional information

**Known limitation.** A *pure* CII EXTENDED-CTC-FR document is CII **D22B**, whereas
`FACTUR-X_EXTENDED.xsd` is D16B-based, so `getValidationXsdFilename()` only covers the
Factur-X flavour cleanly. Detection — what this PR changes — is unaffected.

The UBL half of CTC-FR is deliberately **not** in this PR: it is blocked on the `cbc:ProfileID`
design question raised in the linked issue, and lives in a separate branch.