### PR TITLE
[FIX] UBL readers never read cac:OrderReference/cbc:IssueDate (#26)

### DIFF
--- a/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderReader.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderReader.php
@@ -3579,7 +3579,7 @@ class InvoiceSuitePeppol30CreditNoteProviderReader extends InvoiceSuiteAbstractD
         $documentBuyerOrderReference = $documentBuyerOrderReferences[InvoiceSuitePointerUtils::getValue('documentbuyerorderreference')];
 
         $newReferenceNumber = $documentBuyerOrderReference->getID()?->getValue() ?? '';
-        $newReferenceDate = null;
+        $newReferenceDate = $documentBuyerOrderReference->getIssueDate();
 
         $this->traceMethodExit(__METHOD__);
 

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProviderReader.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProviderReader.php
@@ -3580,7 +3580,7 @@ class InvoiceSuitePeppol30InvoiceProviderReader extends InvoiceSuiteAbstractDocu
         $documentBuyerOrderReference = $documentBuyerOrderReferences[InvoiceSuitePointerUtils::getValue('documentbuyerorderreference')];
 
         $newReferenceNumber = $documentBuyerOrderReference->getID()?->getValue() ?? '';
-        $newReferenceDate = null;
+        $newReferenceDate = $documentBuyerOrderReference->getIssueDate();
 
         $this->traceMethodExit(__METHOD__);
 

--- a/tests/assets/02_technical_xml_ubl_creditnote.xml
+++ b/tests/assets/02_technical_xml_ubl_creditnote.xml
@@ -19,6 +19,7 @@
   <cac:OrderReference>
     <cbc:ID>BO-1</cbc:ID>
     <cbc:SalesOrderID>SO-1</cbc:SalesOrderID>
+    <cbc:IssueDate>1970-01-01</cbc:IssueDate>
   </cac:OrderReference>
   <cac:BillingReference>
     <cac:InvoiceDocumentReference>

--- a/tests/testcases/documentproviders/XRechnungUBLCreditNoteProviderReaderTest.php
+++ b/tests/testcases/documentproviders/XRechnungUBLCreditNoteProviderReaderTest.php
@@ -188,7 +188,8 @@ final class XRechnungUBLCreditNoteProviderReaderTest extends TestCase
         static::$document->getDocumentBuyerOrderReference($newReferenceNumber, $newReferenceDate);
 
         $this->assertSame('BO-1', $newReferenceNumber);
-        $this->assertNotInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertSame('19700101', $newReferenceDate?->format('Ymd'));
 
         $this->assertFalse(static::$document->nextDocumentBuyerOrderReference());
 

--- a/tests/testcases/documentproviders/XRechnungUBLInvoiceProviderReaderTest.php
+++ b/tests/testcases/documentproviders/XRechnungUBLInvoiceProviderReaderTest.php
@@ -188,7 +188,8 @@ final class XRechnungUBLInvoiceProviderReaderTest extends TestCase
         static::$document->getDocumentBuyerOrderReference($newReferenceNumber, $newReferenceDate);
 
         $this->assertSame('BO-1', $newReferenceNumber);
-        $this->assertNotInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertSame('19700101', $newReferenceDate?->format('Ymd'));
 
         $this->assertFalse(static::$document->nextDocumentBuyerOrderReference());
 

--- a/tests/testcases/documentreadbuild/XRechnungUBLCreditNoteReaderTest.php
+++ b/tests/testcases/documentreadbuild/XRechnungUBLCreditNoteReaderTest.php
@@ -189,7 +189,7 @@ final class XRechnungUBLCreditNoteReaderTest extends TestCase
         static::$document->getDocumentBuyerOrderReference($newReferenceNumber, $newReferenceDate);
 
         $this->assertSame('BO-1', $newReferenceNumber);
-        $this->assertNotInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertSame('19700101', $newReferenceDate?->format('Ymd'));
 
         $this->assertFalse(static::$document->nextDocumentBuyerOrderReference());
 

--- a/tests/testcases/documentreadbuild/XRechnungUBLInvoiceReaderTest.php
+++ b/tests/testcases/documentreadbuild/XRechnungUBLInvoiceReaderTest.php
@@ -189,7 +189,7 @@ final class XRechnungUBLInvoiceReaderTest extends TestCase
         static::$document->getDocumentBuyerOrderReference($newReferenceNumber, $newReferenceDate);
 
         $this->assertSame('BO-1', $newReferenceNumber);
-        $this->assertNotInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertSame('19700101', $newReferenceDate?->format('Ymd'));
 
         $this->assertFalse(static::$document->nextDocumentBuyerOrderReference());
 


### PR DESCRIPTION
# Description

UBL readers never read cac:OrderReference/cbc:IssueDate

Related issue: #26 

Fixes: #26 

# Type of change

Select all applicable options.

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring without functional changes
- [ ] Performance improvement
- [ ] Documentation change
- [ ] Breaking change
- [ ] Other
