### PR TITLE
[FIX] Read credit note payment due dates from UBL PaymentMeans (#27)

### DIFF
--- a/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderReader.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderReader.php
@@ -9911,6 +9911,19 @@ class InvoiceSuitePeppol30CreditNoteProviderReader extends InvoiceSuiteAbstractD
         $newDueDate = null;
         $newMandate = '';
 
+        /**
+         * @var array<PaymentMeans>
+         */
+        $documentPaymentMeans = InvoiceSuiteArrayUtils::ensure($this->getUblRootObject()->getPaymentMeans() ?? []);
+
+        $documentPaymentMeansWithDueDate = InvoiceSuiteArrayUtils::filter(
+            $documentPaymentMeans,
+            static fn (PaymentMeans $paymentMean): bool => null !== $paymentMean->getPaymentDueDate()
+        );
+
+        $documentPaymentMean = InvoiceSuiteArrayUtils::first($documentPaymentMeansWithDueDate);
+        $newDueDate = $documentPaymentMean instanceof PaymentMeans ? $documentPaymentMean->getPaymentDueDate() : null;
+
         $this->traceMethodExit(__METHOD__);
 
         return $this;

--- a/tests/assets/02_technical_xml_ubl_creditnote.xml
+++ b/tests/assets/02_technical_xml_ubl_creditnote.xml
@@ -197,6 +197,7 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="name">typecode</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>1970-02-01</cbc:PaymentDueDate>
     <cac:CardAccount>
       <cbc:PrimaryAccountNumberID>financialCardId</cbc:PrimaryAccountNumberID>
       <cbc:NetworkID>mapped-from-cii</cbc:NetworkID>

--- a/tests/testcases/documentproviders/XRechnungUBLCreditNoteProviderReaderTest.php
+++ b/tests/testcases/documentproviders/XRechnungUBLCreditNoteProviderReaderTest.php
@@ -2233,7 +2233,8 @@ final class XRechnungUBLCreditNoteProviderReaderTest extends TestCase
         static::$document->getDocumentPaymentTerm($newDescription, $newDueDate, $newMandate);
 
         $this->assertSame('Payment Term Description 1', $newDescription);
-        $this->assertNotInstanceOf(DateTimeInterface::class, $newDueDate);
+        $this->assertInstanceOf(DateTimeInterface::class, $newDueDate);
+        $this->assertSame('19700201', $newDueDate?->format('Ymd'));
         $this->assertSame('', $newMandate);
 
         // Second Payment Term

--- a/tests/testcases/documentreadbuild/XRechnungUBLCreditNoteReaderTest.php
+++ b/tests/testcases/documentreadbuild/XRechnungUBLCreditNoteReaderTest.php
@@ -2231,7 +2231,8 @@ final class XRechnungUBLCreditNoteReaderTest extends TestCase
         static::$document->getDocumentPaymentTerm($newDescription, $newDueDate, $newMandate);
 
         $this->assertSame('Payment Term Description 1', $newDescription);
-        $this->assertNotInstanceOf(DateTimeInterface::class, $newDueDate);
+        $this->assertInstanceOf(DateTimeInterface::class, $newDueDate);
+        $this->assertSame('19700201', $newDueDate?->format('Ymd'));
         $this->assertSame('', $newMandate);
 
         // Second Payment Term


### PR DESCRIPTION
# Description

Read credit note payment due dates from UBL PaymentMeans (#27)

Related issue: #27 

Fixes: #27 

# Type of change

Select all applicable options.

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring without functional changes
- [ ] Performance improvement
- [ ] Documentation change
- [ ] Breaking change
- [ ] Other
