### PR TITLE
[ENH] Write the buyer's order date for the CTC-FR UBL providers

### DIFF
--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -193,6 +193,7 @@
         <testsuite name="issues">
             <file>../tests/testcases/issues/PaymentTermsWithEmptyDescriptionTest.php</file>
             <file>../tests/testcases/issues/PaymentTermsWithEmptyDescriptionCompatTest.php</file>
+            <file>../tests/testcases/issues/BuyerOrderReferenceIssueDateTest.php</file>
         </testsuite>
     </testsuites>
     <coverage cacheDirectory="phpunit-cache/code-coverage" processUncoveredFiles="true">

--- a/src/documents/providers/ctcfr/InvoiceSuiteCtcFrUBLCreditNoteProvider.php
+++ b/src/documents/providers/ctcfr/InvoiceSuiteCtcFrUBLCreditNoteProvider.php
@@ -49,6 +49,7 @@ class InvoiceSuiteCtcFrUBLCreditNoteProvider extends InvoiceSuitePeppol30CreditN
             //     $documentBuilder->setContextParameter($customizationId, 'B1');
             'ProfileId' => '',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
+            'AllowBuyerOrderReferenceIssueDate' => false,
         ];
     }
 

--- a/src/documents/providers/ctcfr/InvoiceSuiteCtcFrUBLCreditNoteProvider.php
+++ b/src/documents/providers/ctcfr/InvoiceSuiteCtcFrUBLCreditNoteProvider.php
@@ -49,7 +49,15 @@ class InvoiceSuiteCtcFrUBLCreditNoteProvider extends InvoiceSuitePeppol30CreditN
             //     $documentBuilder->setContextParameter($customizationId, 'B1');
             'ProfileId' => '',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
-            'AllowBuyerOrderReferenceIssueDate' => false,
+
+            // EXT-FR-FE-197 "Date de la reference du bon de commande", the date belonging to the
+            // purchase order reference BT-13. AFNOR XP Z12-012 gives it cardinality 0..1 for
+            // EXTENDED FR only: neither EN 16931 nor CIUS FR define it, which is why every other
+            // UBL provider leaves this parameter at false. It maps to
+            // cac:OrderReference/cbc:IssueDate in UBL and to
+            // ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime in CII, which the
+            // EXTENDED-based CII provider already writes as BT-X-147
+            'AllowBuyerOrderReferenceIssueDate' => true,
         ];
     }
 

--- a/src/documents/providers/ctcfr/InvoiceSuiteCtcFrUBLInvoiceProvider.php
+++ b/src/documents/providers/ctcfr/InvoiceSuiteCtcFrUBLInvoiceProvider.php
@@ -49,6 +49,7 @@ class InvoiceSuiteCtcFrUBLInvoiceProvider extends InvoiceSuitePeppol30InvoicePro
             //     $documentBuilder->setContextParameter($customizationId, 'B1');
             'ProfileId' => '',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
+            'AllowBuyerOrderReferenceIssueDate' => false,
         ];
     }
 

--- a/src/documents/providers/ctcfr/InvoiceSuiteCtcFrUBLInvoiceProvider.php
+++ b/src/documents/providers/ctcfr/InvoiceSuiteCtcFrUBLInvoiceProvider.php
@@ -49,7 +49,15 @@ class InvoiceSuiteCtcFrUBLInvoiceProvider extends InvoiceSuitePeppol30InvoicePro
             //     $documentBuilder->setContextParameter($customizationId, 'B1');
             'ProfileId' => '',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
-            'AllowBuyerOrderReferenceIssueDate' => false,
+
+            // EXT-FR-FE-197 "Date de la reference du bon de commande", the date belonging to the
+            // purchase order reference BT-13. AFNOR XP Z12-012 gives it cardinality 0..1 for
+            // EXTENDED FR only: neither EN 16931 nor CIUS FR define it, which is why every other
+            // UBL provider leaves this parameter at false. It maps to
+            // cac:OrderReference/cbc:IssueDate in UBL and to
+            // ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime in CII, which the
+            // EXTENDED-based CII provider already writes as BT-X-147
+            'AllowBuyerOrderReferenceIssueDate' => true,
         ];
     }
 

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProvider.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProvider.php
@@ -63,6 +63,7 @@ class InvoiceSuitePeppol30CreditNoteProvider extends InvoiceSuiteAbstractDocumen
             'CustomizationId' => 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0',
             'ProfileId' => 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
             'AllowInvoiceDocumentReferenceDocumentType' => true,
+            'AllowBuyerOrderReferenceIssueDate' => false,
         ];
     }
 

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderBuilder.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderBuilder.php
@@ -1208,6 +1208,11 @@ class InvoiceSuitePeppol30CreditNoteProviderBuilder extends InvoiceSuiteAbstract
     /**
      * Set the associated buyer's order
      *
+     * EN 16931 defines no term for the buyer's order date at document level, therefore
+     * cbc:IssueDate is only written when the format provider declares the parameter
+     * "AllowBuyerOrderReferenceIssueDate". The CII builder gates the equivalent BT-X-147
+     * in the same way, on the EXTENDED profile.
+     *
      * @param  null|string            $newReferenceNumber Buyers's order number
      * @param  null|DateTimeInterface $newReferenceDate   Buyer's order date
      * @return static
@@ -1228,11 +1233,15 @@ class InvoiceSuitePeppol30CreditNoteProviderBuilder extends InvoiceSuiteAbstract
             return $this->traceMethodEarlyExit(__METHOD__, 'stringIsNullOrEmpty', 'InvoiceSuiteStringUtils::stringIsNullOrEmpty($newReferenceNumber)');
         }
 
-        $this
+        $orderReference = $this
             ->getUblRootObject()
-            ->getOrderReferenceWithCreate()
-            ->getIDWithCreate()
-            ->setValue($newReferenceNumber);
+            ->getOrderReferenceWithCreate();
+
+        $orderReference->getIDWithCreate()->setValue($newReferenceNumber);
+
+        if ($this->getCurrentDocumentFormatProviderParameterValueBool('AllowBuyerOrderReferenceIssueDate', false)) {
+            $orderReference->setIssueDate($newReferenceDate);
+        }
 
         $this->traceMethodExit(__METHOD__);
 

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProvider.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProvider.php
@@ -63,6 +63,7 @@ class InvoiceSuitePeppol30InvoiceProvider extends InvoiceSuiteAbstractDocumentFo
             'CustomizationId' => 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0',
             'ProfileId' => 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
             'AllowInvoiceDocumentReferenceDocumentType' => true,
+            'AllowBuyerOrderReferenceIssueDate' => false,
         ];
     }
 

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProviderBuilder.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProviderBuilder.php
@@ -1212,6 +1212,11 @@ class InvoiceSuitePeppol30InvoiceProviderBuilder extends InvoiceSuiteAbstractDoc
     /**
      * Set the associated buyer's order
      *
+     * EN 16931 defines no term for the buyer's order date at document level, therefore
+     * cbc:IssueDate is only written when the format provider declares the parameter
+     * "AllowBuyerOrderReferenceIssueDate". The CII builder gates the equivalent BT-X-147
+     * in the same way, on the EXTENDED profile.
+     *
      * @param  null|string            $newReferenceNumber Buyers's order number
      * @param  null|DateTimeInterface $newReferenceDate   Buyer's order date
      * @return static
@@ -1232,11 +1237,15 @@ class InvoiceSuitePeppol30InvoiceProviderBuilder extends InvoiceSuiteAbstractDoc
             return $this->traceMethodEarlyExit(__METHOD__, 'stringIsNullOrEmpty', 'InvoiceSuiteStringUtils::stringIsNullOrEmpty($newReferenceNumber)');
         }
 
-        $this
+        $orderReference = $this
             ->getUblRootObject()
-            ->getOrderReferenceWithCreate()
-            ->getIDWithCreate()
-            ->setValue($newReferenceNumber);
+            ->getOrderReferenceWithCreate();
+
+        $orderReference->getIDWithCreate()->setValue($newReferenceNumber);
+
+        if ($this->getCurrentDocumentFormatProviderParameterValueBool('AllowBuyerOrderReferenceIssueDate', false)) {
+            $orderReference->setIssueDate($newReferenceDate);
+        }
 
         $this->traceMethodExit(__METHOD__);
 

--- a/src/documents/providers/peppolselfbilling/InvoiceSuitePeppol30SelfBillingCreditNoteProvider.php
+++ b/src/documents/providers/peppolselfbilling/InvoiceSuitePeppol30SelfBillingCreditNoteProvider.php
@@ -49,6 +49,7 @@ class InvoiceSuitePeppol30SelfBillingCreditNoteProvider extends InvoiceSuitePepp
             'CustomizationId' => 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0',
             'ProfileId' => 'urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
+            'AllowBuyerOrderReferenceIssueDate' => false,
             'AllowedDocumentTypes' => ['261'],
         ];
     }

--- a/src/documents/providers/peppolselfbilling/InvoiceSuitePeppol30SelfBillingInvoiceProvider.php
+++ b/src/documents/providers/peppolselfbilling/InvoiceSuitePeppol30SelfBillingInvoiceProvider.php
@@ -49,6 +49,7 @@ class InvoiceSuitePeppol30SelfBillingInvoiceProvider extends InvoiceSuitePeppol3
             'CustomizationId' => 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0',
             'ProfileId' => 'urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
+            'AllowBuyerOrderReferenceIssueDate' => false,
             'AllowedDocumentTypes' => ['389', '527'],
         ];
     }

--- a/src/documents/providers/pinteu/InvoiceSuitePintEuCreditNoteProvider.php
+++ b/src/documents/providers/pinteu/InvoiceSuitePintEuCreditNoteProvider.php
@@ -40,6 +40,7 @@ class InvoiceSuitePintEuCreditNoteProvider extends InvoiceSuitePeppol30CreditNot
             'CustomizationId' => 'urn:peppol:pint:billing-1@eu-1',
             'ProfileId' => 'urn:peppol:bis:billing',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
+            'AllowBuyerOrderReferenceIssueDate' => false,
             'AllowedDocumentTypes' => ['81', '83', '381', '396', '532'],
         ];
     }

--- a/src/documents/providers/pinteu/InvoiceSuitePintEuInvoiceProvider.php
+++ b/src/documents/providers/pinteu/InvoiceSuitePintEuInvoiceProvider.php
@@ -40,6 +40,7 @@ class InvoiceSuitePintEuInvoiceProvider extends InvoiceSuitePeppol30InvoiceProvi
             'CustomizationId' => 'urn:peppol:pint:billing-1@eu-1',
             'ProfileId' => 'urn:peppol:bis:billing',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
+            'AllowBuyerOrderReferenceIssueDate' => false,
             'AllowedDocumentTypes' => [
                 '71',
                 '80',

--- a/src/documents/providers/xr/InvoiceSuiteXRechnungUBLCreditNoteProvider.php
+++ b/src/documents/providers/xr/InvoiceSuiteXRechnungUBLCreditNoteProvider.php
@@ -65,6 +65,7 @@ class InvoiceSuiteXRechnungUBLCreditNoteProvider extends InvoiceSuiteAbstractDoc
             'CustomizationId' => 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0',
             'ProfileId' => 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
+            'AllowBuyerOrderReferenceIssueDate' => false,
             'AlternativeCustomizationIds' => ['urn:cen.eu:en16931:2017'],
         ];
     }

--- a/src/documents/providers/xr/InvoiceSuiteXRechnungUBLInvoiceProvider.php
+++ b/src/documents/providers/xr/InvoiceSuiteXRechnungUBLInvoiceProvider.php
@@ -65,6 +65,7 @@ class InvoiceSuiteXRechnungUBLInvoiceProvider extends InvoiceSuiteAbstractDocume
             'CustomizationId' => 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0',
             'ProfileId' => 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
             'AllowInvoiceDocumentReferenceDocumentType' => false,
+            'AllowBuyerOrderReferenceIssueDate' => false,
             'AlternativeCustomizationIds' => ['urn:cen.eu:en16931:2017'],
         ];
     }

--- a/tests/testcases/documentproviders/CtcFrUBLCreditNoteProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/CtcFrUBLCreditNoteProviderBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace horstoeko\invoicesuite\tests\testcases\documentproviders;
 
 use DateTime;
+use DateTimeInterface;
 use horstoeko\invoicesuite\documents\providers\ctcfr\InvoiceSuiteCtcFrUBLCreditNoteProvider;
 use horstoeko\invoicesuite\documents\providers\ctcfr\InvoiceSuiteCtcFrUBLCreditNoteProviderBuilder;
 use horstoeko\invoicesuite\documents\providers\peppol\models\main\CreditNote;
@@ -96,6 +97,43 @@ final class CtcFrUBLCreditNoteProviderBuilderTest extends TestCase
 
         $this->assertXPathValue('/ns:CreditNote/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', 'REF-1');
         $this->assertXPathNotExists('/ns:CreditNote/cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentTypeCode');
+    }
+
+    /**
+     * EXT-FR-FE-197, the date of the purchase order reference BT-13, which AFNOR XP Z12-012
+     * defines for EXTENDED FR only and maps to cac:OrderReference/cbc:IssueDate. It is not to be
+     * confused with BT-2, the invoice issue date, which is the cbc:IssueDate on the document root.
+     * 'AllowBuyerOrderReferenceIssueDate' => true is what enables it.
+     */
+    public function testDocumentBuyerOrderReferenceCarriesTheIssueDate(): void
+    {
+        static::$document->setDocumentDate(new DateTime('2026-01-15'));
+        static::$document->setDocumentBuyerOrderReference('BO-1', new DateTime('2026-01-05'));
+
+        $this->assertXPathValue('/ns:CreditNote/cac:OrderReference/cbc:ID', 'BO-1');
+        $this->assertXPathValue('/ns:CreditNote/cac:OrderReference/cbc:IssueDate', '2026-01-05');
+
+        // BT-2 is a different element carrying a different date: the cbc:IssueDate sitting on
+        // the document root, not the one inside cac:OrderReference
+        $this->assertXPathValue('/ns:CreditNote/cbc:IssueDate', '2026-01-15');
+    }
+
+    public function testDocumentBuyerOrderReferenceIssueDateRoundTrip(): void
+    {
+        $documentBuilder = InvoiceSuiteDocumentBuilder::createByProviderUniqueId(InvoiceSuiteBuiltInProviders::CTC_FR_UBL_CREDIT_NOTE);
+        $documentBuilder->setDocumentNo('A-2026-000001');
+        $documentBuilder->setDocumentDate(new DateTime('2026-01-15'));
+        $documentBuilder->setDocumentBuyerOrderReference('BO-1', new DateTime('2026-01-05'));
+
+        $documentReader = $documentBuilder->copyToReader();
+
+        $this->assertTrue($documentReader->firstDocumentBuyerOrderReference());
+
+        $documentReader->getDocumentBuyerOrderReference($newReferenceNumber, $newReferenceDate);
+
+        $this->assertSame('BO-1', $newReferenceNumber);
+        $this->assertInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertSame('20260105', $newReferenceDate->format('Ymd'));
     }
 
     public function testBuildAndDetectRoundTrip(): void

--- a/tests/testcases/documentproviders/CtcFrUBLCreditNoteProviderTest.php
+++ b/tests/testcases/documentproviders/CtcFrUBLCreditNoteProviderTest.php
@@ -59,6 +59,7 @@ final class CtcFrUBLCreditNoteProviderTest extends TestCase
 
         // UBL-CR-026: a CTC-FR document must not carry the BillingReference DocumentTypeCode
         $this->assertFalse($provider->getParameters()['AllowInvoiceDocumentReferenceDocumentType']);
+        $this->assertTrue($provider->getParameters()['AllowBuyerOrderReferenceIssueDate']);
 
         $this->assertArrayNotHasKey('AllowedDocumentTypes', $provider->getParameters());
 

--- a/tests/testcases/documentproviders/CtcFrUBLInvoiceProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/CtcFrUBLInvoiceProviderBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace horstoeko\invoicesuite\tests\testcases\documentproviders;
 
 use DateTime;
+use DateTimeInterface;
 use horstoeko\invoicesuite\documents\providers\ctcfr\InvoiceSuiteCtcFrUBLInvoiceProvider;
 use horstoeko\invoicesuite\documents\providers\ctcfr\InvoiceSuiteCtcFrUBLInvoiceProviderBuilder;
 use horstoeko\invoicesuite\documents\providers\peppol\models\main\Invoice;
@@ -96,6 +97,43 @@ final class CtcFrUBLInvoiceProviderBuilderTest extends TestCase
 
         $this->assertXPathValue('/ns:Invoice/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', 'REF-1');
         $this->assertXPathNotExists('/ns:Invoice/cac:BillingReference/cac:InvoiceDocumentReference/cbc:DocumentTypeCode');
+    }
+
+    /**
+     * EXT-FR-FE-197, the date of the purchase order reference BT-13, which AFNOR XP Z12-012
+     * defines for EXTENDED FR only and maps to cac:OrderReference/cbc:IssueDate. It is not to be
+     * confused with BT-2, the invoice issue date, which is the cbc:IssueDate on the document root.
+     * 'AllowBuyerOrderReferenceIssueDate' => true is what enables it.
+     */
+    public function testDocumentBuyerOrderReferenceCarriesTheIssueDate(): void
+    {
+        static::$document->setDocumentDate(new DateTime('2026-01-15'));
+        static::$document->setDocumentBuyerOrderReference('BO-1', new DateTime('2026-01-05'));
+
+        $this->assertXPathValue('/ns:Invoice/cac:OrderReference/cbc:ID', 'BO-1');
+        $this->assertXPathValue('/ns:Invoice/cac:OrderReference/cbc:IssueDate', '2026-01-05');
+
+        // BT-2 is a different element carrying a different date: the cbc:IssueDate sitting on
+        // the document root, not the one inside cac:OrderReference
+        $this->assertXPathValue('/ns:Invoice/cbc:IssueDate', '2026-01-15');
+    }
+
+    public function testDocumentBuyerOrderReferenceIssueDateRoundTrip(): void
+    {
+        $documentBuilder = InvoiceSuiteDocumentBuilder::createByProviderUniqueId(InvoiceSuiteBuiltInProviders::CTC_FR_UBL_INVOICE);
+        $documentBuilder->setDocumentNo('F-2026-000001');
+        $documentBuilder->setDocumentDate(new DateTime('2026-01-15'));
+        $documentBuilder->setDocumentBuyerOrderReference('BO-1', new DateTime('2026-01-05'));
+
+        $documentReader = $documentBuilder->copyToReader();
+
+        $this->assertTrue($documentReader->firstDocumentBuyerOrderReference());
+
+        $documentReader->getDocumentBuyerOrderReference($newReferenceNumber, $newReferenceDate);
+
+        $this->assertSame('BO-1', $newReferenceNumber);
+        $this->assertInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertSame('20260105', $newReferenceDate->format('Ymd'));
     }
 
     public function testBuildAndDetectRoundTrip(): void

--- a/tests/testcases/documentproviders/CtcFrUBLInvoiceProviderTest.php
+++ b/tests/testcases/documentproviders/CtcFrUBLInvoiceProviderTest.php
@@ -59,6 +59,7 @@ final class CtcFrUBLInvoiceProviderTest extends TestCase
 
         // UBL-CR-026: a CTC-FR document must not carry the BillingReference DocumentTypeCode
         $this->assertFalse($provider->getParameters()['AllowInvoiceDocumentReferenceDocumentType']);
+        $this->assertTrue($provider->getParameters()['AllowBuyerOrderReferenceIssueDate']);
 
         $this->assertArrayNotHasKey('AllowedDocumentTypes', $provider->getParameters());
 

--- a/tests/testcases/issues/BuyerOrderReferenceIssueDateTest.php
+++ b/tests/testcases/issues/BuyerOrderReferenceIssueDateTest.php
@@ -40,14 +40,15 @@ final class BuyerOrderReferenceIssueDateTest extends TestCase
     }
 
     /**
-     * All format providers which use the UBL builders, with the name of their root element
+     * The format providers which use the UBL builders and leave
+     * AllowBuyerOrderReferenceIssueDate at false, with the name of their root element. The CTC-FR
+     * providers are absent on purpose: they enable the parameter, and are covered by
+     * CtcFrUBLInvoiceProviderBuilderTest and CtcFrUBLCreditNoteProviderBuilderTest.
      *
      * @return Iterator<string,array<string>>
      */
     public function ublProviderProvider(): Iterator
     {
-        yield 'ctcfrublinvoice' => ['ctcfrublinvoice', 'Invoice'];
-        yield 'ctcfrublcreditnote' => ['ctcfrublcreditnote', 'CreditNote'];
         yield 'peppol30invoice' => ['peppol30invoice', 'Invoice'];
         yield 'peppol30creditnote' => ['peppol30creditnote', 'CreditNote'];
         yield 'peppol30selfbillinginvoice' => ['peppol30selfbillinginvoice', 'Invoice'];

--- a/tests/testcases/issues/BuyerOrderReferenceIssueDateTest.php
+++ b/tests/testcases/issues/BuyerOrderReferenceIssueDateTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace horstoeko\invoicesuite\tests\testcases\issues;
+
+use DateTime;
+use DateTimeInterface;
+use horstoeko\invoicesuite\documents\abstracts\InvoiceSuiteAbstractDocumentFormatProvider;
+use horstoeko\invoicesuite\documents\providers\xr\InvoiceSuiteXRechnungUBLCreditNoteProvider;
+use horstoeko\invoicesuite\documents\providers\xr\InvoiceSuiteXRechnungUBLInvoiceProvider;
+use horstoeko\invoicesuite\InvoiceSuiteDocumentBuilder;
+use horstoeko\invoicesuite\InvoiceSuiteDocumentReader;
+use horstoeko\invoicesuite\tests\TestCase;
+use horstoeko\invoicesuite\tests\traits\HandlesXmlTests;
+use Iterator;
+
+final class BuyerOrderReferenceIssueDateTest extends TestCase
+{
+    use HandlesXmlTests;
+
+    /**
+     * @param  string $providerUniqueId
+     * @param  string $rootElementName
+     * @return void
+     *
+     * @dataProvider ublProviderProvider
+     */
+    public function testIssueDateIsOmittedByDefault(
+        string $providerUniqueId,
+        string $rootElementName
+    ): void {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId($providerUniqueId);
+        static::$document->setDocumentBuyerOrderReference('BO-1', $this->buyerOrderDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue(sprintf('/ns:%s/cac:OrderReference/cbc:ID', $rootElementName), 'BO-1');
+        $this->assertXPathNotExists(sprintf('/ns:%s/cac:OrderReference/cbc:IssueDate', $rootElementName));
+    }
+
+    /**
+     * All format providers which use the UBL builders, with the name of their root element
+     *
+     * @return Iterator<string,array<string>>
+     */
+    public function ublProviderProvider(): Iterator
+    {
+        yield 'ctcfrublinvoice' => ['ctcfrublinvoice', 'Invoice'];
+        yield 'ctcfrublcreditnote' => ['ctcfrublcreditnote', 'CreditNote'];
+        yield 'peppol30invoice' => ['peppol30invoice', 'Invoice'];
+        yield 'peppol30creditnote' => ['peppol30creditnote', 'CreditNote'];
+        yield 'peppol30selfbillinginvoice' => ['peppol30selfbillinginvoice', 'Invoice'];
+        yield 'peppol30selfbillingcreditnote' => ['peppol30selfbillingcreditnote', 'CreditNote'];
+        yield 'pinteuinvoice' => ['pinteuinvoice', 'Invoice'];
+        yield 'pinteucreditnote' => ['pinteucreditnote', 'CreditNote'];
+        yield 'xrechnungublinvoice' => ['xrechnungublinvoice', 'Invoice'];
+        yield 'xrechnungublcreditnote' => ['xrechnungublcreditnote', 'CreditNote'];
+    }
+
+    public function testInvoiceWritesIssueDateWhenTheProviderAllowsIt(): void
+    {
+        static::$document = $this->invoiceProviderAllowingIssueDate()->getBuilder();
+        static::$document->setDocumentBuyerOrderReference('BO-1', $this->buyerOrderDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:Invoice/cac:OrderReference/cbc:ID', 'BO-1');
+        $this->assertXPathValue('/ns:Invoice/cac:OrderReference/cbc:IssueDate', '1970-01-01');
+    }
+
+    public function testCreditNoteWritesIssueDateWhenTheProviderAllowsIt(): void
+    {
+        static::$document = $this->creditNoteProviderAllowingIssueDate()->getBuilder();
+        static::$document->setDocumentBuyerOrderReference('BO-1', $this->buyerOrderDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:OrderReference/cbc:ID', 'BO-1');
+        $this->assertXPathValue('/ns:CreditNote/cac:OrderReference/cbc:IssueDate', '1970-01-01');
+    }
+
+    public function testIssueDateIsOmittedWhenNoDateIsGiven(): void
+    {
+        static::$document = $this->invoiceProviderAllowingIssueDate()->getBuilder();
+        static::$document->setDocumentBuyerOrderReference('BO-1');
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:Invoice/cac:OrderReference/cbc:ID', 'BO-1');
+        $this->assertXPathNotExists('/ns:Invoice/cac:OrderReference/cbc:IssueDate');
+    }
+
+    public function testIssueDateIsRemovedWhenTheReferenceIsReset(): void
+    {
+        static::$document = $this->invoiceProviderAllowingIssueDate()->getBuilder();
+        static::$document->setDocumentBuyerOrderReference('BO-1', $this->buyerOrderDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:Invoice/cac:OrderReference/cbc:IssueDate', '1970-01-01');
+
+        static::$document->setDocumentBuyerOrderReference('');
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathNotExists('/ns:Invoice/cac:OrderReference/cbc:ID');
+        $this->assertXPathNotExists('/ns:Invoice/cac:OrderReference/cbc:IssueDate');
+    }
+
+    public function testIssueDateSurvivesABuildReadRoundTrip(): void
+    {
+        static::$document = $this->invoiceProviderAllowingIssueDate()->getBuilder();
+        static::$document->setDocumentBuyerOrderReference('BO-1', $this->buyerOrderDate());
+
+        $documentReader = InvoiceSuiteDocumentReader::createFromContent(static::$document->getContent());
+
+        $this->assertTrue($documentReader->firstDocumentBuyerOrderReference());
+
+        $documentReader->getDocumentBuyerOrderReference($newReferenceNumber, $newReferenceDate);
+
+        $this->assertSame('BO-1', $newReferenceNumber);
+        $this->assertInstanceOf(DateTimeInterface::class, $newReferenceDate);
+        $this->assertSame('19700101', $newReferenceDate->format('Ymd'));
+    }
+
+    /**
+     * The buyer's order date used by all test cases
+     *
+     * @return DateTime
+     */
+    private function buyerOrderDate(): DateTime
+    {
+        return (new DateTime())->createFromFormat('d.m.Y', '01.01.1970');
+    }
+
+    /**
+     * An invoice format provider which allows the buyer's order date to be written
+     *
+     * @return InvoiceSuiteAbstractDocumentFormatProvider
+     */
+    private function invoiceProviderAllowingIssueDate(): InvoiceSuiteAbstractDocumentFormatProvider
+    {
+        return new class extends InvoiceSuiteXRechnungUBLInvoiceProvider {
+            /**
+             * {@inheritDoc}
+             */
+            public function getParameters(): array
+            {
+                $parameters = parent::getParameters();
+
+                $parameters['AllowBuyerOrderReferenceIssueDate'] = true;
+
+                return $parameters;
+            }
+        };
+    }
+
+    /**
+     * A credit note format provider which allows the buyer's order date to be written
+     *
+     * @return InvoiceSuiteAbstractDocumentFormatProvider
+     */
+    private function creditNoteProviderAllowingIssueDate(): InvoiceSuiteAbstractDocumentFormatProvider
+    {
+        return new class extends InvoiceSuiteXRechnungUBLCreditNoteProvider {
+            /**
+             * {@inheritDoc}
+             */
+            public function getParameters(): array
+            {
+                $parameters = parent::getParameters();
+
+                $parameters['AllowBuyerOrderReferenceIssueDate'] = true;
+
+                return $parameters;
+            }
+        };
+    }
+}


### PR DESCRIPTION
FNOR XP Z12-012 defines **EXT-FR-FE-197**, "Date de la reference du bon de commande" (the date of
the purchase order reference BT-13) with cardinality `0..1` **for EXTENDED FR only**. Neither
EN 16931 nor CIUS FR define it, which is precisely why the parameter has to be decided per provider
rather than globally.

| Term | UBL | CII |
| --- | --- | --- |
| BT-13 | `/cac:OrderReference/cbc:ID` | `…/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID` |
| EXT-FR-FE-197 | `/cac:OrderReference/cbc:IssueDate` | `…/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime` |

`InvoiceSuiteZfFxExtendedCtcFrProvider` already writes this as BT-X-147, because it builds on the
EXTENDED profile. This commit makes the UBL side carry the same information, so the two CTC-FR
syntaxes stop disagreeing.

Not to be confused with BT-2, the invoice issue date, which is the `cbc:IssueDate` on the document
root. Both appear in the same document:

```xml
<cbc:IssueDate>2026-01-15</cbc:IssueDate>          <!-- BT-2 -->
<cac:OrderReference>
  <cbc:ID>BON-CDE-42</cbc:ID>                      <!-- BT-13 -->
  <cbc:SalesOrderID>SO-7</cbc:SalesOrderID>        <!-- BT-14 -->
  <cbc:IssueDate>2026-01-05</cbc:IssueDate>        <!-- EXT-FR-FE-197 -->
</cac:OrderReference>
```

Issues: https://github.com/horstoeko/invoicesuite/issues/26

Fixes: #26 

# Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring without functional changes
- [ ] Performance improvement
- [ ] Documentation change
- [ ] Breaking change
- [ ] Other

# Mandatory checklist

- [x] This pull request contains one logical change.
- [x] I have explained why this change is necessary.
- [x] I have personally reviewed every changed file.
- [x] I understand the submitted code and can explain how it works.
- [x] I have tested the change locally.
- [x] Existing tests pass locally.
- [x] My changes introduce no new warnings or static-analysis errors.
- [x] I have added or updated meaningful tests where applicable.
- [x] I have updated the documentation where necessary.
- [x] I have not included unrelated formatting, generated, or mechanical changes.
- [x] I accept full responsibility for automated or AI-assisted content contained in this pull request.