### PR TITLE
[Fix] Write credit note payment due dates

### DIFF
--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -194,6 +194,7 @@
             <file>../tests/testcases/issues/PaymentTermsWithEmptyDescriptionTest.php</file>
             <file>../tests/testcases/issues/PaymentTermsWithEmptyDescriptionCompatTest.php</file>
             <file>../tests/testcases/issues/BuyerOrderReferenceIssueDateTest.php</file>
+            <file>../tests/testcases/issues/CreditNotePaymentDueDateTest.php</file>
         </testsuite>
     </testsuites>
     <coverage cacheDirectory="phpunit-cache/code-coverage" processUncoveredFiles="true">

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderBuilder.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderBuilder.php
@@ -13,6 +13,7 @@ namespace horstoeko\invoicesuite\documents\providers\peppol;
 
 use DateTimeInterface;
 use horstoeko\invoicesuite\codelists\InvoiceSuiteCodelistPaymentMeans;
+use horstoeko\invoicesuite\concerns\HandlesKeyValuePairs;
 use horstoeko\invoicesuite\documents\abstracts\InvoiceSuiteAbstractDocumentFormatBuilder;
 use horstoeko\invoicesuite\documents\dto\InvoiceSuiteAddressDTO;
 use horstoeko\invoicesuite\documents\dto\InvoiceSuiteAllowanceChargeDTO;
@@ -36,6 +37,7 @@ use horstoeko\invoicesuite\documents\dto\InvoiceSuiteReferenceDocumentLineDTO;
 use horstoeko\invoicesuite\documents\dto\InvoiceSuiteSummationDTO;
 use horstoeko\invoicesuite\documents\dto\InvoiceSuiteTaxDTO;
 use horstoeko\invoicesuite\documents\providers\peppol\models\cac\PartyIdentification;
+use horstoeko\invoicesuite\documents\providers\peppol\models\cac\PaymentMeans;
 use horstoeko\invoicesuite\documents\providers\peppol\models\main\CreditNote;
 use horstoeko\invoicesuite\utils\InvoiceSuiteArrayUtils;
 use horstoeko\invoicesuite\utils\InvoiceSuiteAttachment;
@@ -45,6 +47,8 @@ use horstoeko\invoicesuite\utils\InvoiceSuiteStringUtils;
 
 class InvoiceSuitePeppol30CreditNoteProviderBuilder extends InvoiceSuiteAbstractDocumentFormatBuilder
 {
+    use HandlesKeyValuePairs;
+
     /**
      * {@inheritDoc}
      */
@@ -7736,6 +7740,8 @@ class InvoiceSuitePeppol30CreditNoteProviderBuilder extends InvoiceSuiteAbstract
             $paymentMean->addOnceToPaymentIDWithCreate()->setValue($newPaymentReference);
         }
 
+        $this->updateDueDates();
+
         $this->traceMethodExit(__METHOD__);
 
         return $this;
@@ -8137,6 +8143,11 @@ class InvoiceSuitePeppol30CreditNoteProviderBuilder extends InvoiceSuiteAbstract
     /**
      * Set payment term
      *
+     * BT-9 is written even when BT-20 is empty, mirroring the CII builders: the two terms are
+     * independent in EN 16931 (BT-9 is 0..1 on its own) and cac:PaymentTerms is only created
+     * when there actually is a note, since Peppol allows no other child there. For credit
+     * notes BT-9 lives in cac:PaymentMeans/cbc:PaymentDueDate, see updateDueDates().
+     *
      * @param  null|string            $newDescription Text description of the payment terms
      * @param  null|DateTimeInterface $newDueDate     Date by which payment is due
      * @param  null|string            $newMandate     Identification of the mandate reference
@@ -8153,15 +8164,27 @@ class InvoiceSuitePeppol30CreditNoteProviderBuilder extends InvoiceSuiteAbstract
             ->getUblRootObject()
             ->unsetPaymentTerms();
 
-        if (InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)) {
+        if (
+            InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)
+            && InvoiceSuiteDateTimeUtils::dateTimeIsNullOrEmpty($newDueDate)
+        ) {
+            $this->removeKeyValuePair('duedatefrompaymentterm');
+
             return $this->traceMethodEarlyExit(__METHOD__, 'stringIsNullOrEmpty', 'InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)');
         }
 
-        $this
-            ->getUblRootObject()
-            ->addOnceToPaymentTermsWithCreate()
-            ->addToNoteWithCreate()
-            ->setValue($newDescription);
+        if (!InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)) {
+            $this
+                ->getUblRootObject()
+                ->addOnceToPaymentTermsWithCreate()
+                ->addToNoteWithCreate()
+                ->setValue($newDescription);
+        }
+
+        if (!InvoiceSuiteDateTimeUtils::dateTimeIsNullOrEmpty($newDueDate)) {
+            $this->addKeyValuePair('duedatefrompaymentterm', $newDueDate, true);
+            $this->updateDueDates();
+        }
 
         $this->traceMethodExit(__METHOD__);
 
@@ -8183,7 +8206,10 @@ class InvoiceSuitePeppol30CreditNoteProviderBuilder extends InvoiceSuiteAbstract
     ): static {
         $this->traceMethodEnter(__METHOD__);
 
-        if (InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)) {
+        if (
+            InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)
+            && InvoiceSuiteDateTimeUtils::dateTimeIsNullOrEmpty($newDueDate)
+        ) {
             return $this->traceMethodEarlyExit(__METHOD__, 'stringIsNullOrEmpty', 'InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)');
         }
 
@@ -11078,5 +11104,38 @@ class InvoiceSuitePeppol30CreditNoteProviderBuilder extends InvoiceSuiteAbstract
         }
 
         return $newTaxRegistrationType;
+    }
+
+    /**
+     * Update the payment due date in the payment means
+     *
+     * EN 16931 binds BT-9 to cac:PaymentMeans/cbc:PaymentDueDate for UBL credit notes,
+     * because the CreditNote schema has no cbc:DueDate of its own. The date is remembered
+     * when the payment term is set and re-applied whenever a payment mean is added, so the
+     * order of the calls does not matter. No cac:PaymentMeans is created on purpose: Peppol
+     * requires cbc:PaymentMeansCode inside it, so synthesizing one would emit an invalid
+     * document.
+     *
+     * @return static
+     */
+    private function updateDueDates(): static
+    {
+        $documentPaymentDueDate = $this->getKeyValuePair('duedatefrompaymentterm', null);
+
+        if (!$documentPaymentDueDate instanceof DateTimeInterface) {
+            return $this;
+        }
+
+        $documentPaymentMeans = $this
+            ->getUblRootObject()
+            ->getPaymentMeans() ?? [];
+
+        $documentFirstPaymentMean = InvoiceSuiteArrayUtils::first($documentPaymentMeans);
+
+        if ($documentFirstPaymentMean instanceof PaymentMeans) {
+            $documentFirstPaymentMean->setPaymentDueDate($documentPaymentDueDate);
+        }
+
+        return $this;
     }
 }

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderReader.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30CreditNoteProviderReader.php
@@ -9856,9 +9856,7 @@ class InvoiceSuitePeppol30CreditNoteProviderReader extends InvoiceSuiteAbstractD
     public function firstDocumentPaymentTerm(): bool
     {
         return InvoiceSuitePointerUtils::hasFirst(
-            InvoiceSuiteArrayUtils::ensure(
-                $this->getUblRootObject()->getPaymentTerms() ?? []
-            ),
+            $this->resolveDocumentPaymentTerms(),
             'documentpaymentterm'
         );
     }
@@ -9871,9 +9869,7 @@ class InvoiceSuitePeppol30CreditNoteProviderReader extends InvoiceSuiteAbstractD
     public function nextDocumentPaymentTerm(): bool
     {
         return InvoiceSuitePointerUtils::hasNext(
-            InvoiceSuiteArrayUtils::ensure(
-                $this->getUblRootObject()->getPaymentTerms() ?? []
-            ),
+            $this->resolveDocumentPaymentTerms(),
             'documentpaymentterm'
         );
     }
@@ -9897,10 +9893,7 @@ class InvoiceSuitePeppol30CreditNoteProviderReader extends InvoiceSuiteAbstractD
     ): static {
         $this->traceMethodEnter(__METHOD__);
 
-        /**
-         * @var array<PaymentTerms>
-         */
-        $documentPaymentTerms = InvoiceSuiteArrayUtils::ensure($this->getUblRootObject()->getPaymentTerms() ?? []);
+        $documentPaymentTerms = $this->resolveDocumentPaymentTerms();
 
         /**
          * @var PaymentTerms
@@ -9908,21 +9901,8 @@ class InvoiceSuitePeppol30CreditNoteProviderReader extends InvoiceSuiteAbstractD
         $documentPaymentTerm = $documentPaymentTerms[InvoiceSuitePointerUtils::getValue('documentpaymentterm')];
 
         $newDescription = $documentPaymentTerm->firstNote()?->getValue() ?? '';
-        $newDueDate = null;
+        $newDueDate = $this->resolveDocumentPaymentDueDate();
         $newMandate = '';
-
-        /**
-         * @var array<PaymentMeans>
-         */
-        $documentPaymentMeans = InvoiceSuiteArrayUtils::ensure($this->getUblRootObject()->getPaymentMeans() ?? []);
-
-        $documentPaymentMeansWithDueDate = InvoiceSuiteArrayUtils::filter(
-            $documentPaymentMeans,
-            static fn (PaymentMeans $paymentMean): bool => null !== $paymentMean->getPaymentDueDate()
-        );
-
-        $documentPaymentMean = InvoiceSuiteArrayUtils::first($documentPaymentMeansWithDueDate);
-        $newDueDate = $documentPaymentMean instanceof PaymentMeans ? $documentPaymentMean->getPaymentDueDate() : null;
 
         $this->traceMethodExit(__METHOD__);
 
@@ -12841,5 +12821,59 @@ class InvoiceSuitePeppol30CreditNoteProviderReader extends InvoiceSuiteAbstractD
         return InvoiceSuiteArrayUtils::values(
             InvoiceSuiteArrayUtils::filter($partyIdentifications ?? [], static fn (PartyIdentification $id): bool => InvoiceSuiteStringUtils::equalsNoCase($id->getID()?->getSchemeID() ?? '', 'SEPA'))
         );
+    }
+
+    /**
+     * Internal helper for resolving the payment terms
+     *
+     * BT-9 is bound to cac:PaymentMeans/cbc:PaymentDueDate for UBL credit notes and is valid
+     * on its own: BR-CO-25 asks for either BT-9 or BT-20, so a document may carry a due date
+     * with no cac:PaymentTerms at all. One empty payment term is exposed in that case, so the
+     * due date stays reachable through the regular payment term iteration.
+     *
+     * @return array<PaymentTerms>
+     */
+    private function resolveDocumentPaymentTerms(): array
+    {
+        /**
+         * @var array<PaymentTerms>
+         */
+        $documentPaymentTerms = InvoiceSuiteArrayUtils::ensure($this->getUblRootObject()->getPaymentTerms() ?? []);
+
+        if ([] !== $documentPaymentTerms) {
+            return $documentPaymentTerms;
+        }
+
+        if (!$this->resolveDocumentPaymentDueDate() instanceof DateTimeInterface) {
+            return [];
+        }
+
+        return [new PaymentTerms()];
+    }
+
+    /**
+     * Internal helper for resolving the payment due date
+     *
+     * The UBL CreditNote schema has no cbc:DueDate, so Peppol binds BT-9 to
+     * cac:PaymentMeans/cbc:PaymentDueDate. The first payment mean carrying one wins, which
+     * also matches UBL-SR-45 allowing the element at most once per document.
+     *
+     * @return null|DateTimeInterface
+     */
+    private function resolveDocumentPaymentDueDate(): ?DateTimeInterface
+    {
+        /**
+         * @var array<PaymentMeans>
+         */
+        $documentPaymentMeans = InvoiceSuiteArrayUtils::ensure($this->getUblRootObject()->getPaymentMeans() ?? []);
+
+        $documentPaymentMeansWithDueDate = InvoiceSuiteArrayUtils::filter(
+            $documentPaymentMeans,
+            static fn (PaymentMeans $paymentMean): bool => $paymentMean->getPaymentDueDate() instanceof DateTimeInterface
+        );
+
+        $documentPaymentMean = InvoiceSuiteArrayUtils::first($documentPaymentMeansWithDueDate);
+
+        return $documentPaymentMean instanceof PaymentMeans ? $documentPaymentMean->getPaymentDueDate() : null;
     }
 }

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProviderBuilder.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProviderBuilder.php
@@ -8159,6 +8159,13 @@ class InvoiceSuitePeppol30InvoiceProviderBuilder extends InvoiceSuiteAbstractDoc
     /**
      * Set payment term
      *
+     * BT-9 is written even when BT-20 is empty: the two terms are independent in EN 16931
+     * (BT-9 is 0..1 on its own, and BR-CO-25 asks for either of them) and cac:PaymentTerms is
+     * only created when there actually is a note, since Peppol allows no other child there.
+     * BT-89 stays tied to a non-empty BT-20 on purpose, because updateMandates() writes it
+     * without looking at cbc:PaymentMeansCode, which BR-DE-23-b and BR-DE-24-b forbid outside
+     * a direct debit.
+     *
      * @param  null|string            $newDescription Text description of the payment terms
      * @param  null|DateTimeInterface $newDueDate     Date by which payment is due
      * @param  null|string            $newMandate     Identification of the mandate reference
@@ -8175,15 +8182,20 @@ class InvoiceSuitePeppol30InvoiceProviderBuilder extends InvoiceSuiteAbstractDoc
             ->getUblRootObject()
             ->unsetPaymentTerms();
 
-        if (InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)) {
+        if (
+            InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)
+            && InvoiceSuiteDateTimeUtils::dateTimeIsNullOrEmpty($newDueDate)
+        ) {
             return $this->traceMethodEarlyExit(__METHOD__, 'stringIsNullOrEmpty', 'InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)');
         }
 
-        $this
-            ->getUblRootObject()
-            ->addOnceToPaymentTermsWithCreate()
-            ->addToNoteWithCreate()
-            ->setValue($newDescription);
+        if (!InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)) {
+            $this
+                ->getUblRootObject()
+                ->addOnceToPaymentTermsWithCreate()
+                ->addToNoteWithCreate()
+                ->setValue($newDescription);
+        }
 
         if (!InvoiceSuiteDateTimeUtils::dateTimeIsNullOrEmpty($newDueDate)) {
             $this->getUblRootObject()->setDueDate($newDueDate);
@@ -8214,7 +8226,10 @@ class InvoiceSuitePeppol30InvoiceProviderBuilder extends InvoiceSuiteAbstractDoc
     ): static {
         $this->traceMethodEnter(__METHOD__);
 
-        if (InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)) {
+        if (
+            InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)
+            && InvoiceSuiteDateTimeUtils::dateTimeIsNullOrEmpty($newDueDate)
+        ) {
             return $this->traceMethodEarlyExit(__METHOD__, 'stringIsNullOrEmpty', 'InvoiceSuiteStringUtils::stringIsNullOrEmpty($newDescription)');
         }
 

--- a/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProviderReader.php
+++ b/src/documents/providers/peppol/InvoiceSuitePeppol30InvoiceProviderReader.php
@@ -9877,9 +9877,7 @@ class InvoiceSuitePeppol30InvoiceProviderReader extends InvoiceSuiteAbstractDocu
     public function firstDocumentPaymentTerm(): bool
     {
         return InvoiceSuitePointerUtils::hasFirst(
-            InvoiceSuiteArrayUtils::ensure(
-                $this->getUblRootObject()->getPaymentTerms() ?? []
-            ),
+            $this->resolveDocumentPaymentTerms(),
             'documentpaymentterm'
         );
     }
@@ -9892,9 +9890,7 @@ class InvoiceSuitePeppol30InvoiceProviderReader extends InvoiceSuiteAbstractDocu
     public function nextDocumentPaymentTerm(): bool
     {
         return InvoiceSuitePointerUtils::hasNext(
-            InvoiceSuiteArrayUtils::ensure(
-                $this->getUblRootObject()->getPaymentTerms() ?? []
-            ),
+            $this->resolveDocumentPaymentTerms(),
             'documentpaymentterm'
         );
     }
@@ -9918,10 +9914,7 @@ class InvoiceSuitePeppol30InvoiceProviderReader extends InvoiceSuiteAbstractDocu
     ): static {
         $this->traceMethodEnter(__METHOD__);
 
-        /**
-         * @var array<PaymentTerms>
-         */
-        $documentPaymentTerms = InvoiceSuiteArrayUtils::ensure($this->getUblRootObject()->getPaymentTerms() ?? []);
+        $documentPaymentTerms = $this->resolveDocumentPaymentTerms();
 
         /**
          * @var PaymentTerms
@@ -12849,5 +12842,33 @@ class InvoiceSuitePeppol30InvoiceProviderReader extends InvoiceSuiteAbstractDocu
         return InvoiceSuiteArrayUtils::values(
             InvoiceSuiteArrayUtils::filter($partyIdentifications ?? [], static fn (PartyIdentification $id): bool => InvoiceSuiteStringUtils::equalsNoCase($id->getID()?->getSchemeID() ?? '', 'SEPA'))
         );
+    }
+
+    /**
+     * Internal helper for resolving the payment terms
+     *
+     * BT-9 is bound to cbc:DueDate for UBL invoices and is valid on its own: BR-CO-25 asks for
+     * either BT-9 or BT-20, so a document may carry a due date with no cac:PaymentTerms at all.
+     * One empty payment term is exposed in that case, so the due date stays reachable through
+     * the regular payment term iteration.
+     *
+     * @return array<PaymentTerms>
+     */
+    private function resolveDocumentPaymentTerms(): array
+    {
+        /**
+         * @var array<PaymentTerms>
+         */
+        $documentPaymentTerms = InvoiceSuiteArrayUtils::ensure($this->getUblRootObject()->getPaymentTerms() ?? []);
+
+        if ([] !== $documentPaymentTerms) {
+            return $documentPaymentTerms;
+        }
+
+        if (!$this->getUblRootObject()->getDueDate() instanceof DateTimeInterface) {
+            return [];
+        }
+
+        return [new PaymentTerms()];
     }
 }

--- a/tests/testcases/documentcases/XRechnungUBLCreditNoteDocumentBuilderDTOTest.php
+++ b/tests/testcases/documentcases/XRechnungUBLCreditNoteDocumentBuilderDTOTest.php
@@ -137,6 +137,7 @@ final class XRechnungUBLCreditNoteDocumentBuilderDTOTest extends TestCase
             ->addPaymentTerm(
                 (new InvoiceSuitePaymentTermDTO())
                     ->setDescription('Payment within 10 days, 2% discount')
+                    ->setDueDate(DateTime::createFromFormat('Ymd', '20171123'))
             )
             ->addAllowanceCharge(
                 (new InvoiceSuiteAllowanceChargeDTO())
@@ -456,6 +457,8 @@ final class XRechnungUBLCreditNoteDocumentBuilderDTOTest extends TestCase
 
         $this->assertXPathValue('/ubl:CreditNote/cac:PaymentTerms/cbc:Note', 'Payment within 10 days, 2% discount');
         $this->assertXPathNotExists('(/ubl:CreditNote/cac:PaymentTerms/cbc:Note)[2]');
+        $this->assertXPathValue('/ubl:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '2017-11-23');
+        $this->assertXPathNotExists('(/ubl:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate)[2]');
 
         // Allowances/Charges
 

--- a/tests/testcases/documentcases/XRechnungUBLCreditNoteDocumentBuilderTest.php
+++ b/tests/testcases/documentcases/XRechnungUBLCreditNoteDocumentBuilderTest.php
@@ -91,7 +91,7 @@ final class XRechnungUBLCreditNoteDocumentBuilderTest extends TestCase
             newPaymentReference: 'Snippet1'
         );
 
-        static::$document->setDocumentPaymentTerm('Payment within 10 days, 2% discount');
+        static::$document->setDocumentPaymentTerm('Payment within 10 days, 2% discount', DateTime::createFromFormat('Ymd', '20171123'));
 
         static::$document->setDocumentAllowanceCharge(
             newChargeIndicator: true,
@@ -353,6 +353,8 @@ final class XRechnungUBLCreditNoteDocumentBuilderTest extends TestCase
 
         $this->assertXPathValue('/ubl:CreditNote/cac:PaymentTerms/cbc:Note', 'Payment within 10 days, 2% discount');
         $this->assertXPathNotExists('(/ubl:CreditNote/cac:PaymentTerms/cbc:Note)[2]');
+        $this->assertXPathValue('/ubl:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '2017-11-23');
+        $this->assertXPathNotExists('(/ubl:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate)[2]');
 
         // Allowances/Charges
 

--- a/tests/testcases/documentcases/XRechnungUBLInvoiceDocumentBuilderDTOTest.php
+++ b/tests/testcases/documentcases/XRechnungUBLInvoiceDocumentBuilderDTOTest.php
@@ -106,6 +106,7 @@ final class XRechnungUBLInvoiceDocumentBuilderDTOTest extends TestCase
                 ->setPercent(19.00))
             ->addPaymentTerm((new InvoiceSuitePaymentTermDTO())
                 ->setDescription('Zahlbar innerhalb 30 Tagen netto bis 15.12.2024, 3% Skonto innerhalb 10 Tagen bis 25.11.2024')
+                ->setDueDate(DateTime::createFromFormat('Ymd', '20241215'))
                 ->setMandate('z3237167126'))
             ->addPaymentMean((new InvoiceSuitePaymentMeanDTO())
                 ->setTypeCode('59')
@@ -358,6 +359,8 @@ final class XRechnungUBLInvoiceDocumentBuilderDTOTest extends TestCase
 
         $this->assertXPathValue('/ubl:Invoice/cac:PaymentTerms/cbc:Note', 'Zahlbar innerhalb 30 Tagen netto bis 15.12.2024, 3% Skonto innerhalb 10 Tagen bis 25.11.2024');
         $this->assertXPathNotExists('(/ubl:Invoice/cac:PaymentTerms/cbc:Note)[2]');
+        $this->assertXPathValue('/ubl:Invoice/cbc:DueDate', '2024-12-15');
+        $this->assertXPathNotExists('(/ubl:Invoice/cbc:DueDate)[2]');
 
         $this->assertXPathValue('/ubl:Invoice/cac:PaymentMeans/cbc:PaymentMeansCode', '59');
         $this->assertXPathValue('/ubl:Invoice/cac:PaymentMeans/cac:PaymentMandate/cbc:ID', 'z3237167126');

--- a/tests/testcases/documentcases/XRechnungUBLInvoiceDocumentBuilderTest.php
+++ b/tests/testcases/documentcases/XRechnungUBLInvoiceDocumentBuilderTest.php
@@ -114,7 +114,7 @@ final class XRechnungUBLInvoiceDocumentBuilderTest extends TestCase
             newTaxPercent: 19.00
         );
 
-        static::$document->addDocumentPaymentTerm('Zahlbar innerhalb 30 Tagen netto bis 15.12.2024, 3% Skonto innerhalb 10 Tagen bis 25.11.2024', null, 'z3237167126');
+        static::$document->addDocumentPaymentTerm('Zahlbar innerhalb 30 Tagen netto bis 15.12.2024, 3% Skonto innerhalb 10 Tagen bis 25.11.2024', DateTime::createFromFormat('Ymd', '20241215'), 'z3237167126');
 
         static::$document->setDocumentPaymentMean(
             newTypeCode: '59',
@@ -320,6 +320,8 @@ final class XRechnungUBLInvoiceDocumentBuilderTest extends TestCase
 
         $this->assertXPathValue('/ubl:Invoice/cac:PaymentTerms/cbc:Note', 'Zahlbar innerhalb 30 Tagen netto bis 15.12.2024, 3% Skonto innerhalb 10 Tagen bis 25.11.2024');
         $this->assertXPathNotExists('(/ubl:Invoice/cac:PaymentTerms/cbc:Note)[2]');
+        $this->assertXPathValue('/ubl:Invoice/cbc:DueDate', '2024-12-15');
+        $this->assertXPathNotExists('(/ubl:Invoice/cbc:DueDate)[2]');
 
         $this->assertXPathValue('/ubl:Invoice/cac:PaymentMeans/cbc:PaymentMeansCode', '59');
         $this->assertXPathValue('/ubl:Invoice/cac:PaymentMeans/cac:PaymentMandate/cbc:ID', 'z3237167126');

--- a/tests/testcases/documentproviders/XRechnungUBLCreditNoteProviderBuilderTest.php
+++ b/tests/testcases/documentproviders/XRechnungUBLCreditNoteProviderBuilderTest.php
@@ -5723,6 +5723,8 @@ final class XRechnungUBLCreditNoteProviderBuilderTest extends TestCase
 
         $this->assertXPathValue('/ns:CreditNote/cac:PaymentTerms/cbc:Note', 'Term3');
         $this->assertXPathNotExists('/ns:CreditNote/cbc:DueDate');
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans[1]/cbc:PaymentDueDate', '1970-01-01');
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentMeans[position() > 1]/cbc:PaymentDueDate');
         $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentTerms/cbc:Note)[2]');
         $this->assertXPathNotExists('(/ns:CreditNote/cbc:DueDate)[2]');
         $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentTerms/cbc:Note)[3]');

--- a/tests/testcases/documentreadbuild/XRechnungUBLCreditNoteBuilderTest.php
+++ b/tests/testcases/documentreadbuild/XRechnungUBLCreditNoteBuilderTest.php
@@ -5564,6 +5564,8 @@ final class XRechnungUBLCreditNoteBuilderTest extends TestCase
 
         $this->assertXPathValue('/ns:CreditNote/cac:PaymentTerms/cbc:Note', 'Term3');
         $this->assertXPathNotExists('/ns:CreditNote/cbc:DueDate');
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans[1]/cbc:PaymentDueDate', '1970-01-01');
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentMeans[position() > 1]/cbc:PaymentDueDate');
         $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentTerms/cbc:Note)[2]');
         $this->assertXPathNotExists('(/ns:CreditNote/cbc:DueDate)[2]');
         $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentTerms/cbc:Note)[3]');

--- a/tests/testcases/issues/CreditNotePaymentDueDateTest.php
+++ b/tests/testcases/issues/CreditNotePaymentDueDateTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace horstoeko\invoicesuite\tests\testcases\issues;
+
+use DateTime;
+use DateTimeInterface;
+use horstoeko\invoicesuite\InvoiceSuiteDocumentBuilder;
+use horstoeko\invoicesuite\InvoiceSuiteDocumentReader;
+use horstoeko\invoicesuite\tests\TestCase;
+use horstoeko\invoicesuite\tests\traits\HandlesXmlTests;
+use Iterator;
+
+final class CreditNotePaymentDueDateTest extends TestCase
+{
+    use HandlesXmlTests;
+
+    /**
+     * @param  string $providerUniqueId
+     * @return void
+     *
+     * @dataProvider ublCreditNoteProviderProvider
+     */
+    public function testDueDateIsWrittenForEveryUblCreditNoteProvider(
+        string $providerUniqueId
+    ): void {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId($providerUniqueId);
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->setDocumentPaymentTerm('Term', $this->paymentDueDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-01-31');
+    }
+
+    /**
+     * All UBL credit note format providers, which all inherit the Peppol 3.0 builder
+     *
+     * @return Iterator<string, array<string>>
+     */
+    public static function ublCreditNoteProviderProvider(): Iterator
+    {
+        yield 'xrechnung' => ['xrechnungublcreditnote'];
+        yield 'peppol30' => ['peppol30creditnote'];
+        yield 'peppol30selfbilling' => ['peppol30selfbillingcreditnote'];
+        yield 'pinteu' => ['pinteucreditnote'];
+        yield 'ctcfr' => ['ctcfrublcreditnote'];
+    }
+
+    public function testDueDateIsAppliedWhenThePaymentMeanIsAddedAfterwards(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->setDocumentPaymentTerm('Term', $this->paymentDueDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentMeans');
+
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-01-31');
+    }
+
+    public function testDueDateIsWrittenToTheFirstPaymentMeanOnly(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202052');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202053');
+        static::$document->setDocumentPaymentTerm('Term', $this->paymentDueDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans[1]/cbc:PaymentDueDate', '1970-01-31');
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentMeans[position() > 1]/cbc:PaymentDueDate');
+    }
+
+    public function testTheLastDueDateWins(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->setDocumentPaymentTerm('Term', $this->paymentDueDate());
+        static::$document->setDocumentPaymentTerm('Term', (new DateTime())->createFromFormat('d.m.Y', '01.02.1970'));
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-02-01');
+        $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate)[2]');
+    }
+
+    public function testDueDateIsReappliedWhenThePaymentMeansAreReset(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->setDocumentPaymentTerm('Term', $this->paymentDueDate());
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-01-31');
+
+        static::$document->setDocumentPaymentMean(newTypeCode: '58', newPayeeIban: 'DE02120300000000202052');
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentMeansCode', '58');
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-01-31');
+    }
+
+    public function testNoPaymentDueDateIsWrittenWithoutADate(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->setDocumentPaymentTerm('Term');
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentTerms/cbc:Note', 'Term');
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate');
+    }
+
+    public function testAddDocumentPaymentTermDoesNotApplyTheDueDateTwice(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->addDocumentPaymentTerm('Term', $this->paymentDueDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentTerms/cbc:Note', 'Term');
+        $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentTerms/cbc:Note)[2]');
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-01-31');
+        $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate)[2]');
+    }
+
+    public function testDueDateSurvivesABuildReadRoundTrip(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->setDocumentPaymentTerm('Term', $this->paymentDueDate());
+
+        $documentReader = InvoiceSuiteDocumentReader::createFromContent(static::$document->getContent());
+
+        $this->assertTrue($documentReader->firstDocumentPaymentTerm());
+
+        $documentReader->getDocumentPaymentTerm($newDescription, $newDueDate, $newMandate);
+
+        $this->assertSame('Term', $newDescription);
+        $this->assertInstanceOf(DateTimeInterface::class, $newDueDate);
+        $this->assertSame('19700131', $newDueDate->format('Ymd'));
+    }
+
+    public function testDueDateIsForgottenWhenThePaymentTermIsReset(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->setDocumentPaymentTerm('Term', $this->paymentDueDate());
+        static::$document->setDocumentPaymentTerm();
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentTerms');
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate');
+    }
+
+    public function testAddDocumentPaymentTermWithoutDescriptionReplacesTheTerm(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->setDocumentPaymentTerm('Term');
+        static::$document->addDocumentPaymentTerm(null, $this->paymentDueDate());
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentTerms');
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-01-31');
+    }
+
+    public function testDueDateSurvivesARoundTripWithoutADescription(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->setDocumentPaymentTerm(null, $this->paymentDueDate());
+
+        $documentReader = InvoiceSuiteDocumentReader::createFromContent(static::$document->getContent());
+
+        $this->assertTrue($documentReader->firstDocumentPaymentTerm());
+
+        $documentReader->getDocumentPaymentTerm($newDescription, $newDueDate, $newMandate);
+
+        $this->assertSame('', $newDescription);
+        $this->assertInstanceOf(DateTimeInterface::class, $newDueDate);
+        $this->assertSame('19700131', $newDueDate->format('Ymd'));
+    }
+
+    public function testNoPaymentTermIsReportedWithoutADueDate(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+        static::$document->addDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+
+        $documentReader = InvoiceSuiteDocumentReader::createFromContent(static::$document->getContent());
+
+        $this->assertFalse($documentReader->firstDocumentPaymentTerm());
+    }
+
+    /**
+     * The payment due date used by all test cases
+     *
+     * @return DateTime
+     */
+    private function paymentDueDate(): DateTime
+    {
+        return (new DateTime())->createFromFormat('d.m.Y', '31.01.1970');
+    }
+}

--- a/tests/testcases/issues/PaymentTermsWithEmptyDescriptionTest.php
+++ b/tests/testcases/issues/PaymentTermsWithEmptyDescriptionTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace horstoeko\invoicesuite\tests\testcases\issues;
 
 use DateTime;
+use DateTimeInterface;
 use horstoeko\invoicesuite\InvoiceSuiteDocumentBuilder;
+use horstoeko\invoicesuite\InvoiceSuiteDocumentReader;
 use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\tests\TestCase;
 use horstoeko\invoicesuite\tests\traits\HandlesXmlTests;
@@ -127,5 +129,85 @@ final class PaymentTermsWithEmptyDescriptionTest extends TestCase
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description)[3]');
         $this->assertXPathNotExists('(/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString[@format="102"])[3]');
         $this->assertXPathNotExists('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID[3]');
+    }
+
+    public function testXmlOutputXRechnungUblInvoice(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublinvoice');
+
+        static::$document->setDocumentPaymentTerm();
+
+        $this->assertXPathNotExists('/ns:Invoice/cac:PaymentTerms');
+        $this->assertXPathNotExists('/ns:Invoice/cbc:DueDate');
+
+        static::$document->setDocumentPaymentTerm('');
+
+        $this->assertXPathNotExists('/ns:Invoice/cac:PaymentTerms');
+        $this->assertXPathNotExists('/ns:Invoice/cbc:DueDate');
+
+        static::$document->setDocumentPaymentTerm(null, (new DateTime())->createFromFormat('d.m.Y', '31.01.1970'));
+
+        $this->assertXPathNotExists('/ns:Invoice/cac:PaymentTerms');
+        $this->assertXPathValue('/ns:Invoice/cbc:DueDate', '1970-01-31');
+
+        // BT-89 stays tied to a non-empty BT-20: updateMandates() does not look at
+        // cbc:PaymentMeansCode, and BR-DE-23-b forbids BG-19 outside a direct debit.
+        static::$document->setDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+        static::$document->setDocumentPaymentTerm(null, null, 'z3237167126');
+
+        $this->assertXPathNotExists('/ns:Invoice/cac:PaymentTerms');
+        $this->assertXPathNotExists('/ns:Invoice/cac:PaymentMeans/cac:PaymentMandate/cbc:ID');
+
+        static::$document->setDocumentPaymentTerm('Zahlbar innerhalb 30 Tagen netto', (new DateTime())->createFromFormat('d.m.Y', '01.02.1970'));
+
+        $this->assertXPathValue('/ns:Invoice/cac:PaymentTerms/cbc:Note', 'Zahlbar innerhalb 30 Tagen netto');
+        $this->assertXPathValue('/ns:Invoice/cbc:DueDate', '1970-02-01');
+        $this->assertXPathNotExists('(/ns:Invoice/cac:PaymentTerms/cbc:Note)[2]');
+        $this->assertXPathNotExists('(/ns:Invoice/cbc:DueDate)[2]');
+    }
+
+    public function testXmlOutputXRechnungUblCreditNote(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublcreditnote');
+
+        static::$document->setDocumentPaymentTerm();
+
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentTerms');
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate');
+
+        static::$document->setDocumentPaymentTerm('');
+
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentTerms');
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate');
+
+        static::$document->setDocumentPaymentMean(newTypeCode: '30', newPayeeIban: 'DE02120300000000202051');
+
+        static::$document->setDocumentPaymentTerm(null, (new DateTime())->createFromFormat('d.m.Y', '31.01.1970'));
+
+        $this->assertXPathNotExists('/ns:CreditNote/cac:PaymentTerms');
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-01-31');
+
+        static::$document->setDocumentPaymentTerm('Zahlbar innerhalb 30 Tagen netto', (new DateTime())->createFromFormat('d.m.Y', '01.02.1970'));
+
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentTerms/cbc:Note', 'Zahlbar innerhalb 30 Tagen netto');
+        $this->assertXPathValue('/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', '1970-02-01');
+        $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentTerms/cbc:Note)[2]');
+        $this->assertXPathNotExists('(/ns:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate)[2]');
+    }
+
+    public function testUblInvoiceDueDateIsReadableWithoutADescription(): void
+    {
+        static::$document = InvoiceSuiteDocumentBuilder::createByProviderUniqueId('xrechnungublinvoice');
+        static::$document->setDocumentPaymentTerm(null, (new DateTime())->createFromFormat('d.m.Y', '31.01.1970'));
+
+        $documentReader = InvoiceSuiteDocumentReader::createFromContent(static::$document->getContent());
+
+        $this->assertTrue($documentReader->firstDocumentPaymentTerm());
+
+        $documentReader->getDocumentPaymentTerm($newDescription, $newDueDate, $newMandate);
+
+        $this->assertSame('', $newDescription);
+        $this->assertInstanceOf(DateTimeInterface::class, $newDueDate);
+        $this->assertSame('19700131', $newDueDate->format('Ymd'));
     }
 }


### PR DESCRIPTION
Fixes the write side of #27.

#29 fixed reading BT-9 from UBL credit notes. Writing it was still broken, in two
independent ways, both in `setDocumentPaymentTerm()`.

Issues: https://github.com/horstoeko/invoicesuite/issues/27

# Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring without functional changes
- [ ] Performance improvement
- [ ] Documentation change
- [ ] Breaking change
- [ ] Other

# Mandatory checklist

- [x] This pull request contains one logical change.
- [x] I have explained why this change is necessary.
- [x] I have personally reviewed every changed file.
- [x] I understand the submitted code and can explain how it works.
- [x] I have tested the change locally.
- [x] Existing tests pass locally.
- [x] My changes introduce no new warnings or static-analysis errors.
- [x] I have added or updated meaningful tests where applicable.
- [x] I have updated the documentation where necessary.
- [x] I have not included unrelated formatting, generated, or mechanical changes.
- [x] I accept full responsibility for automated or AI-assisted content contained in this pull request.