### PR TITLE
[ENH] Add InvoiceSuiteSettings configurations to all commands as global options

### DIFF
--- a/src/console/commands/InvoiceSuiteAbstractCommand.php
+++ b/src/console/commands/InvoiceSuiteAbstractCommand.php
@@ -312,6 +312,20 @@ abstract class InvoiceSuiteAbstractCommand extends Command
     }
 
     /**
+     * Check if an option was actually given a value on the command line,
+     *
+     * @param  string $name
+     * @return bool
+     *
+     * @throws ConsoleInvalidArgumentException
+     */
+    protected function hasOptionValue(
+        string $name
+    ): bool {
+        return null !== $this->input->getOption($name);
+    }
+
+    /**
      * Get a string option.
      *
      * @param  string $name

--- a/src/console/commands/InvoiceSuiteCacheRebuildCommand.php
+++ b/src/console/commands/InvoiceSuiteCacheRebuildCommand.php
@@ -12,10 +12,12 @@ declare(strict_types=1);
 namespace horstoeko\invoicesuite\console\commands;
 
 use horstoeko\invoicesuite\documents\abstracts\InvoiceSuiteAbstractDocumentFormatProvider;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\utils\InvoiceSuiteArrayUtils;
 use horstoeko\invoicesuite\utils\InvoiceSuiteClassFinder;
 use horstoeko\invoicesuite\utils\InvoiceSuiteStringUtils;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Class representing a console command that rebuilds the InvoiceSuite cache.
@@ -38,15 +40,22 @@ class InvoiceSuiteCacheRebuildCommand extends InvoiceSuiteAbstractCommand
     {
         $this->setName('invoicesuite:cache:rebuild');
         $this->setDescription('Rebuild InvoiceSuite class finder cache files');
+        $this->addOption('discovery-namespace', 'N', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'A namespace to restrict document format provider discovery to (repeatable)');
     }
 
     /**
      * Execute command.
      *
      * @return int
+     *
+     * @throws InvalidArgumentException
      */
     protected function handle(): int
     {
+        if ($this->hasOptionValue('discovery-namespace')) {
+            InvoiceSuiteSettings::setDiscoveryNamespaces($this->getStringArrayOption('discovery-namespace'));
+        }
+
         InvoiceSuiteClassFinder::clearCache();
 
         $documentFormatProviderClasses = InvoiceSuiteClassFinder::factory()

--- a/src/console/commands/InvoiceSuiteDetectCommand.php
+++ b/src/console/commands/InvoiceSuiteDetectCommand.php
@@ -18,6 +18,7 @@ use horstoeko\invoicesuite\exceptions\InvoiceSuiteInternalMethodCallException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteUnknownContentException;
 use horstoeko\invoicesuite\InvoiceSuiteDocumentReader;
 use horstoeko\invoicesuite\InvoiceSuitePdfDocumentReader;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\utils\InvoiceSuiteArrayUtils;
 use horstoeko\invoicesuite\utils\InvoiceSuiteStringUtils;
 use PrinsFrank\PdfParser\Exception\PdfParserException;
@@ -50,6 +51,8 @@ class InvoiceSuiteDetectCommand extends InvoiceSuiteAbstractCommand
         $this->setDescription('Detect the format of the given file');
         $this->addArgument('input-file', InputArgument::REQUIRED, 'The file to detect the format of');
         $this->addOption('output-json', null, InputOption::VALUE_NONE, 'Output results as JSON');
+        $this->addOption('discovery-namespace', 'N', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'A namespace to restrict document format provider discovery to (repeatable)');
+        $this->addOption('cache-directory', 'c', InputOption::VALUE_OPTIONAL, 'The cache directory for the internal serializer');
     }
 
     /**
@@ -68,6 +71,14 @@ class InvoiceSuiteDetectCommand extends InvoiceSuiteAbstractCommand
      */
     protected function handle(): int
     {
+        if ($this->hasOptionValue('discovery-namespace')) {
+            InvoiceSuiteSettings::setDiscoveryNamespaces($this->getStringArrayOption('discovery-namespace'));
+        }
+
+        if ($this->hasOptionValue('cache-directory')) {
+            InvoiceSuiteSettings::setSerializerCacheDirectory($this->getStringOption('cache-directory'));
+        }
+
         $inpArgFilename = $this->getSourceFileArgument('input-file');
 
         if ($this->isPdfFile($inpArgFilename)) {

--- a/src/console/commands/InvoiceSuiteExportPdfAttachmentsCommand.php
+++ b/src/console/commands/InvoiceSuiteExportPdfAttachmentsCommand.php
@@ -17,6 +17,7 @@ use horstoeko\invoicesuite\exceptions\InvoiceSuiteFormatProviderNotFoundExceptio
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteInternalMethodCallException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteUnknownContentException;
 use horstoeko\invoicesuite\InvoiceSuitePdfDocumentReader;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\pdfs\extractor\InvoiceSuitePdfExtractorAttachment;
 use horstoeko\invoicesuite\utils\InvoiceSuiteArrayUtils;
 use horstoeko\invoicesuite\utils\InvoiceSuiteFileUtils;
@@ -62,6 +63,8 @@ class InvoiceSuiteExportPdfAttachmentsCommand extends InvoiceSuiteAbstractComman
         $this->addArgument('target-directory', InputArgument::REQUIRED, 'The target directory for extracted attachment files or the generated JSON export file');
         $this->addOption('output-json', null, InputOption::VALUE_REQUIRED, 'Output extracted attachments as JSON (0 = Nothing, 1 = File, 2 = Screen, 3 = File and Screen; default: 0)', self::OUTPUT_JSON_NONE);
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite target files if they already exist');
+        $this->addOption('discovery-namespace', 'N', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'A namespace to restrict document format provider discovery to (repeatable)');
+        $this->addOption('cache-directory', 'c', InputOption::VALUE_OPTIONAL, 'The cache directory for the internal serializer');
     }
 
     /**
@@ -80,6 +83,14 @@ class InvoiceSuiteExportPdfAttachmentsCommand extends InvoiceSuiteAbstractComman
      */
     protected function handle(): int
     {
+        if ($this->hasOptionValue('discovery-namespace')) {
+            InvoiceSuiteSettings::setDiscoveryNamespaces($this->getStringArrayOption('discovery-namespace'));
+        }
+
+        if ($this->hasOptionValue('cache-directory')) {
+            InvoiceSuiteSettings::setSerializerCacheDirectory($this->getStringOption('cache-directory'));
+        }
+
         $inpArgPdfFilename = $this->getSourcePdfFileArgument('input-file');
         $inpArgTargetDirectory = $this->getTargetDirectoryArgument('target-directory');
         $inpOptionJsonOutputMode = $this->getStringOption('output-json', self::OUTPUT_JSON_NONE);

--- a/src/console/commands/InvoiceSuiteListProvidersCommand.php
+++ b/src/console/commands/InvoiceSuiteListProvidersCommand.php
@@ -13,6 +13,7 @@ namespace horstoeko\invoicesuite\console\commands;
 
 use horstoeko\invoicesuite\concerns\HandlesDocumentFormatProviders;
 use horstoeko\invoicesuite\documents\abstracts\InvoiceSuiteAbstractDocumentFormatProvider;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\utils\InvoiceSuiteArrayUtils;
 use horstoeko\invoicesuite\utils\InvoiceSuiteStringUtils;
 use RuntimeException;
@@ -44,6 +45,7 @@ class InvoiceSuiteListProvidersCommand extends InvoiceSuiteAbstractCommand
         $this->setName('invoicesuite:providers:list');
         $this->setDescription('List all available document format providers');
         $this->addOption('output-json', null, InputOption::VALUE_NONE, 'Output results as JSON');
+        $this->addOption('discovery-namespace', 'N', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'A namespace to restrict document format provider discovery to (repeatable)');
     }
 
     /**
@@ -56,6 +58,10 @@ class InvoiceSuiteListProvidersCommand extends InvoiceSuiteAbstractCommand
      */
     protected function handle(): int
     {
+        if ($this->hasOptionValue('discovery-namespace')) {
+            InvoiceSuiteSettings::setDiscoveryNamespaces($this->getStringArrayOption('discovery-namespace'));
+        }
+
         $this->resolveAvailableDocumentFormatProviders();
 
         $jsonRowsToOutput = InvoiceSuiteArrayUtils::map(

--- a/src/console/commands/InvoiceSuiteMergePdfCommand.php
+++ b/src/console/commands/InvoiceSuiteMergePdfCommand.php
@@ -15,6 +15,7 @@ use horstoeko\invoicesuite\exceptions\InvoiceSuiteFileNotFoundException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteFileNotReadableException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteFormatProviderNotFoundException;
 use horstoeko\invoicesuite\InvoiceSuitePdfDocumentBuilder;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\utils\InvoiceSuiteStringUtils;
 use RuntimeException;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
@@ -46,6 +47,7 @@ class InvoiceSuiteMergePdfCommand extends InvoiceSuiteAbstractCommand
         $this->addArgument('pdf-file', InputArgument::REQUIRED, 'The PDF file to use as base document');
         $this->addArgument('output-file', InputArgument::REQUIRED, 'The target PDF file');
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite the target PDF file if it already exists');
+        $this->addOption('discovery-namespace', 'N', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'A namespace to restrict document format provider discovery to (repeatable)');
     }
 
     /**
@@ -61,6 +63,10 @@ class InvoiceSuiteMergePdfCommand extends InvoiceSuiteAbstractCommand
      */
     protected function handle(): int
     {
+        if ($this->hasOptionValue('discovery-namespace')) {
+            InvoiceSuiteSettings::setDiscoveryNamespaces($this->getStringArrayOption('discovery-namespace'));
+        }
+
         $inpArgXmlOrJsonFilename = $this->getSourceXmlOrJsonFileArgument('document-file');
         $inpArgPdfFilename = $this->getSourcePdfFileArgument('pdf-file');
         $inpArgOutputFilename = $this->getTargetFileArgument('output-file', $this->getBoolOption('force'));

--- a/src/console/commands/InvoiceSuiteValidateCommand.php
+++ b/src/console/commands/InvoiceSuiteValidateCommand.php
@@ -16,6 +16,7 @@ use horstoeko\invoicesuite\exceptions\InvoiceSuiteFileNotReadableException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteFormatProviderNotFoundException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteInvalidArgumentException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteValidationContentNotSpecifiedException;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\utils\InvoiceSuiteArrayUtils;
 use horstoeko\invoicesuite\utils\InvoiceSuiteStringUtils;
 use horstoeko\invoicesuite\validators\abstracts\InvoiceSuiteAbstractDocumentValidator;
@@ -69,6 +70,7 @@ class InvoiceSuiteValidateCommand extends InvoiceSuiteAbstractCommand
         $this->addOption('kosit-remote-port', null, InputOption::VALUE_REQUIRED, 'Remote KoSIT validator port');
         $this->addOption('docuflair-base-url', null, InputOption::VALUE_REQUIRED, 'Docuflair API base url');
         $this->addOption('docuflair-api-key', null, InputOption::VALUE_REQUIRED, 'Docuflair personal API key');
+        $this->addOption('discovery-namespace', 'N', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'A namespace to restrict document format provider discovery to (repeatable)');
     }
 
     /**
@@ -88,6 +90,10 @@ class InvoiceSuiteValidateCommand extends InvoiceSuiteAbstractCommand
      */
     protected function handle(): int
     {
+        if ($this->hasOptionValue('discovery-namespace')) {
+            InvoiceSuiteSettings::setDiscoveryNamespaces($this->getStringArrayOption('discovery-namespace'));
+        }
+
         $inpArgFilename = $this->getSourceXmlOrJsonFileArgument('input-file');
         $inpOptionValidator = $this->getStringOption('validator', 'all');
 

--- a/src/console/commands/InvoiceSuiteVisualizeCommand.php
+++ b/src/console/commands/InvoiceSuiteVisualizeCommand.php
@@ -19,6 +19,7 @@ use horstoeko\invoicesuite\exceptions\InvoiceSuiteTemplateNotFoundException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteTemplateNotSpecifiedException;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteUnknownContentException;
 use horstoeko\invoicesuite\InvoiceSuitePdfDocumentBuilder;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\utils\InvoiceSuiteArrayUtils;
 use horstoeko\invoicesuite\utils\InvoiceSuiteStringUtils;
 use horstoeko\invoicesuite\visualizers\InvoiceSuiteVisualizer;
@@ -60,6 +61,8 @@ class InvoiceSuiteVisualizeCommand extends InvoiceSuiteAbstractCommand
         $this->addOption('pdf-orientation', null, InputOption::VALUE_REQUIRED, 'Set the PDF orientation (P, L)', 'P');
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite the target file if it already exists');
         $this->addOption('embed', null, InputOption::VALUE_NONE, 'Embed invoice document to the target PDF file');
+        $this->addOption('discovery-namespace', 'N', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'A namespace to restrict document format provider discovery to (repeatable)');
+        $this->addOption('cache-directory', 'c', InputOption::VALUE_OPTIONAL, 'The cache directory for the internal serializer');
     }
 
     /**
@@ -80,6 +83,14 @@ class InvoiceSuiteVisualizeCommand extends InvoiceSuiteAbstractCommand
      */
     protected function handle(): int
     {
+        if ($this->hasOptionValue('discovery-namespace')) {
+            InvoiceSuiteSettings::setDiscoveryNamespaces($this->getStringArrayOption('discovery-namespace'));
+        }
+
+        if ($this->hasOptionValue('cache-directory')) {
+            InvoiceSuiteSettings::setSerializerCacheDirectory($this->getStringOption('cache-directory'));
+        }
+
         $inpArgInputFilename = $this->getSourceXmlOrJsonFileArgument('input-file');
         $inpArgOutputFilename = $this->getTargetFileArgument('output-file', $this->getBoolOption('force'));
         $inpOptionFormat = $this->getStringOption('format', 'pdf');

--- a/tests/testcases/console/InvoiceSuiteCacheRebuildCommandTest.php
+++ b/tests/testcases/console/InvoiceSuiteCacheRebuildCommandTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace horstoeko\invoicesuite\tests\testcases\console;
 
+use horstoeko\invoicesuite\documents\abstracts\InvoiceSuiteAbstractDocumentFormatProvider;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use horstoeko\invoicesuite\utils\InvoiceSuiteClassFinder;
 use horstoeko\invoicesuite\utils\InvoiceSuitePathUtils;
 use Symfony\Component\Console\Command\Command;
@@ -38,5 +40,33 @@ final class InvoiceSuiteCacheRebuildCommandTest extends InvoiceSuiteConsoleComma
         $this->assertFileDoesNotExist($obsoleteCacheFilename);
         $this->assertStringContainsString('Cache rebuilt.', $commandTester->getDisplay());
         $this->assertStringContainsString('document format providers found.', $commandTester->getDisplay());
+    }
+
+    /**
+     * Test that the command restricts discovery to the given namespace.
+     *
+     * @return void
+     */
+    public function testCommandRebuildsCacheFilesWithNamespaceFilter(): void
+    {
+        $namespace = 'horstoeko\invoicesuite\documents\providers\peppol';
+        $cacheKey = InvoiceSuiteAbstractDocumentFormatProvider::class . '|' . $namespace;
+        $cacheFilename = InvoiceSuitePathUtils::combineAllPaths(dirname(__DIR__, 3), 'src', 'cache', md5((string) preg_replace('/[^a-zA-Z0-9]/', '', sprintf('invoicesuite-cf-%s', $cacheKey))) . '.cache');
+
+        $this->registerFileForTestMethodTeardown($cacheFilename);
+
+        InvoiceSuiteClassFinder::clearCache();
+
+        $commandTester = $this->createCommandTester('invoicesuite:cache:rebuild');
+
+        $exitCode = $commandTester->execute([
+            '--discovery-namespace' => [$namespace],
+        ]);
+
+        InvoiceSuiteSettings::setDiscoveryNamespaces([]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertFileExists($cacheFilename);
+        $this->assertStringContainsString('Cache rebuilt. 2 document format providers found.', $commandTester->getDisplay());
     }
 }

--- a/tests/testcases/console/InvoiceSuiteDetectCommandTest.php
+++ b/tests/testcases/console/InvoiceSuiteDetectCommandTest.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace horstoeko\invoicesuite\tests\testcases\console;
 
+use FilesystemIterator;
 use horstoeko\invoicesuite\exceptions\InvoiceSuiteFileNotFoundException;
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
+use horstoeko\invoicesuite\utils\InvoiceSuitePathUtils;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use Symfony\Component\Console\Command\Command;
 
 final class InvoiceSuiteDetectCommandTest extends InvoiceSuiteConsoleCommandTestCase
@@ -220,5 +225,46 @@ final class InvoiceSuiteDetectCommandTest extends InvoiceSuiteConsoleCommandTest
         $this->assertStringContainsString('unknown', $commandOutput);
         $this->assertStringContainsString('Error', $commandOutput);
         $this->assertStringContainsString('Yes', $commandOutput);
+    }
+
+    /**
+     * Test that the command writes serializer cache files to the given cache directory.
+     *
+     * @return void
+     */
+    public function testCommandUsesGivenCacheDirectory(): void
+    {
+        $cacheDirectory = InvoiceSuitePathUtils::combinePathWithFile(sys_get_temp_dir(), 'invoicesuite-test-cache-' . uniqid());
+
+        mkdir($cacheDirectory, 0777, true);
+
+        $commandTester = $this->createCommandTester('invoicesuite:detect');
+
+        $exitCode = $commandTester->execute([
+            'input-file' => $this->getTestAssetFilePath('00_case_comfort_simple.xml'),
+            '--output-json' => true,
+            '--cache-directory' => $cacheDirectory,
+        ]);
+
+        InvoiceSuiteSettings::setSerializerCacheDirectory('');
+
+        $cacheFiles = [];
+        $directoryIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($cacheDirectory, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($directoryIterator as $item) {
+            if ($item->isFile()) {
+                $cacheFiles[] = $item->getPathname();
+            }
+
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($cacheDirectory);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertNotEmpty($cacheFiles);
     }
 }

--- a/tests/testcases/console/InvoiceSuiteListProvidersCommandTest.php
+++ b/tests/testcases/console/InvoiceSuiteListProvidersCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace horstoeko\invoicesuite\tests\testcases\console;
 
+use horstoeko\invoicesuite\InvoiceSuiteSettings;
 use Symfony\Component\Console\Command\Command;
 
 final class InvoiceSuiteListProvidersCommandTest extends InvoiceSuiteConsoleCommandTestCase
@@ -55,5 +56,36 @@ final class InvoiceSuiteListProvidersCommandTest extends InvoiceSuiteConsoleComm
         $this->assertStringContainsString('│ Content-Type', $commandOutput);
         $this->assertStringContainsString('│ PDF', $commandOutput);
         $this->assertStringContainsString('│ XSD', $commandOutput);
+    }
+
+    /**
+     * Test that the command restricts discovery to the given namespace.
+     *
+     * @return void
+     */
+    public function testCommandListsProvidersFilteredByNamespace(): void
+    {
+        $commandTester = $this->createCommandTester('invoicesuite:providers:list');
+
+        $exitCode = $commandTester->execute([
+            '--output-json' => true,
+            '--discovery-namespace' => ['horstoeko\invoicesuite\documents\providers\peppol'],
+        ]);
+
+        InvoiceSuiteSettings::setDiscoveryNamespaces([]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+
+        $decodedOutput = $this->decodeJsonOutput($commandTester->getDisplay());
+
+        $this->assertIsArray($decodedOutput);
+        $this->assertCount(2, $decodedOutput);
+        $this->assertArrayHasKey(0, $decodedOutput);
+        $this->assertIsArray($decodedOutput[0]);
+        $this->assertArrayHasKey('id', $decodedOutput[0]);
+        $this->assertArrayHasKey('description', $decodedOutput[0]);
+        $this->assertArrayHasKey('contentType', $decodedOutput[0]);
+        $this->assertArrayHasKey('pdfSupportAvailable', $decodedOutput[0]);
+        $this->assertArrayHasKey('xsdValidationAvailable', $decodedOutput[0]);
     }
 }


### PR DESCRIPTION
# Description

The console commands should follow a similar configuration pattern as the API does.

This change should ensure the API is synced with same functionality as console commands are, especially for cache building operations that can depend on discover namespaces field

Related issue: This is the second half of #33

# Type of change

Select all applicable options.

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring without functional changes
- [ ] Performance improvement
- [ ] Documentation change
- [ ] Breaking change
- [ ] Other

# Testing

I run the tests commands which were provided as samples in #33 with extra `-N` argument:
```
vendor/bin/invoicesuite invoicesuite:cache:rebuild -N horstoeko\\invoicesuite
```
Both test examples passed.

**Test configuration**

- Operating system: Linux
- PHP version: 8.5

# Mandatory checklist

- [x] This pull request contains one logical change.
- [x] I have explained why this change is necessary.
- [x] I have personally reviewed every changed file.
- [x] I understand the submitted code and can explain how it works.
- [x] I have tested the change locally.
- [ ] Existing tests pass locally.
- [x] My changes introduce no new warnings or static-analysis errors.
- [x] I have added or updated meaningful tests where applicable.
- [ ] I have updated the documentation where necessary.
- [x] I have not included unrelated formatting, generated, or mechanical changes.
- [x] I accept full responsibility for automated or AI-assisted content contained in this pull request.

# Additional information

The options are defined as global, meaning all commands can set these settings even if the command itself does not use that parameter. This provides a clean solution though adds noise to the command documentation. I don't see this as an issue because the suite settings are meant to be global regardless of what you do.